### PR TITLE
Add boilerplate files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,29 @@
+# This is the official list of benchmark authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
+#
+# Names should be added to this file as:
+#	Name or Organization <email address>
+# The email address is not required for organizations.
+#
+# Please keep the list sorted.
+
+Alex Cohn <alex@alexcohn.com>
+Comodo CA Limited
+Ed Maste <emaste@freebsd.org>
+Elisha Silas <silaselisha66@gmail.com>
+Fiaz Hossain <fiaz.hossain@salesforce.com>
+Google LLC
+Internet Security Research Group
+Jeff Trawick <trawick@gmail.com>
+Katriel Cohn-Gordon <katriel.cohn-gordon@cybersecurity.ox.ac.uk>
+Laël Cellier <lael.cellier@gmail.com>
+Mark Schloesser <ms@mwcollect.org>
+NORDUnet A/S
+Nicholas Galbreath <nickg@client9.com>
+Oliver Weidner <Oliver.Weidner@gmail.com>
+PrimeKey Solutions AB
+Ruslan Kovalov <ruslan.kovalyov@gmail.com>
+Venafi, Inc.
+Vladimir Rutsky <vladimir@rutsky.org>
+Ximin Luo <infinity0@gmx.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# How to contribute #
+
+We'd love to accept your patches and contributions to this project.  There are
+a just a few small guidelines you need to follow.
+
+
+## Contributor License Agreement ##
+
+Contributions to any Google project must be accompanied by a Contributor
+License Agreement.  This is not a copyright **assignment**, it simply gives
+Google permission to use and redistribute your contributions as part of the
+project.
+
+  * If you are an individual writing original source code and you're sure you
+    own the intellectual property, then you'll need to sign an [individual
+    CLA][].
+
+  * If you work for a company that wants to allow you to contribute your work,
+    then you'll need to sign a [corporate CLA][].
+
+You generally only need to submit a CLA once, so if you've already submitted
+one (even if it was for a different project), you probably don't need to do it
+again.
+
+[individual CLA]: https://developers.google.com/open-source/cla/individual
+[corporate CLA]: https://developers.google.com/open-source/cla/corporate
+
+Once your CLA is submitted (or if you already submitted one for
+another Google project), make a commit adding yourself to the
+[AUTHORS][] and [CONTRIBUTORS][] files. This commit can be part
+of your first [pull request][].
+
+[AUTHORS]: AUTHORS
+[CONTRIBUTORS]: CONTRIBUTORS
+
+
+## Submitting a patch ##
+
+  1. It's generally best to start by opening a new issue describing the bug or
+     feature you're intending to fix.  Even if you think it's relatively minor,
+     it's helpful to know what people are working on.  Mention in the initial
+     issue that you are planning to work on that bug or feature so that it can
+     be assigned to you.
+
+  1. Follow the normal process of [forking][] the project, and setup a new
+     branch to work in.  It's important that each group of changes be done in
+     separate branches in order to ensure that a pull request only includes the
+     commits related to that bug or feature.
+
+  1. Do your best to have [well-formed commit messages][] for each change.
+     This provides consistency throughout the project, and ensures that commit
+     messages are able to be formatted properly by various git tools.
+
+  1. Finally, push the commits to your fork and submit a [pull request][].
+
+[forking]: https://help.github.com/articles/fork-a-repo
+[well-formed commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[pull request]: https://help.github.com/articles/creating-a-pull-request

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,62 @@
+# People who have agreed to one of the CLAs and can contribute patches.
+# The AUTHORS file lists the copyright holders; this file
+# lists people.  For example, Google employees are listed here
+# but not in AUTHORS, because Google holds the copyright.
+#
+# Names should be added to this file only after verifying that
+# the individual or the individual's organization has agreed to
+# the appropriate Contributor License Agreement, found here:
+#
+# https://developers.google.com/open-source/cla/individual
+# https://developers.google.com/open-source/cla/corporate
+#
+# The agreement for individuals can be filled out on the web.
+#
+# When adding J Random Contributor's name to this file,
+# either J's name or J's organization's name should be
+# added to the AUTHORS file, depending on whether the
+# individual or corporate CLA was used.
+#
+# Names should be added to this file as:
+#     Name <email address>
+#
+# Please keep the list sorted.
+
+Adam Eijdenberg <eijdenberg@google.com> <adam.eijdenberg@gmail.com>
+Al Cutter <al@google.com>
+Alex Cohn <alex@alexcohn.com>
+Ben Laurie <benl@google.com> <ben@links.org>
+Chris Kennelly <ckennelly@google.com> <ckennelly@ckennelly.com>
+David Drysdale <drysdale@google.com>
+Deyan Bektchiev <deyan.bektchiev@venafi.com> <deyan@bektchiev.net>
+Ed Maste <emaste@freebsd.org>
+Elisha Silas <silaselisha66@gmail.com>
+Emilia Kasper <ekasper@google.com>
+Eran Messeri <eranm@google.com> <eran.mes@gmail.com>
+Fiaz Hossain <fiaz.hossain@salesforce.com>
+Gary Belvin <gbelvin@google.com> <gdbelvin@gmail.com>
+Jeff Trawick <trawick@gmail.com>
+Joe Tsai <joetsai@digital-static.net>
+Kat Joyce <katjoyce@google.com>
+Katriel Cohn-Gordon <katriel.cohn-gordon@cybersecurity.ox.ac.uk>
+Kiril Nikolov <kiril.nikolov@venafi.com>
+Konrad Kraszewski <kraszewski@google.com> <laiquendir@gmail.com>
+Laël Cellier <lael.cellier@gmail.com>
+Linus Nordberg <linus@nordu.net>
+Mark Schloesser <ms@mwcollect.org>
+Nicholas Galbreath <nickg@client9.com>
+Oliver Weidner <Oliver.Weidner@gmail.com>
+Pascal Leroy <phl@google.com>
+Paul Hadfield <hadfieldp@google.com> <paul@phad.org.uk>
+Paul Lietar <lietar@google.com>
+Pavel Kalinnikov <pkalinnikov@google.com> <pavelkalinnikov@gmail.com>
+Pierre Phaneuf <pphaneuf@google.com>
+Rob Percival <robpercival@google.com>
+Rob Stradling <rob@comodo.com>
+Roger Ng <rogerng@google.com> <roger2hk@gmail.com>
+Roland Shoemaker <roland@letsencrypt.org>
+Ruslan Kovalov <ruslan.kovalyov@gmail.com>
+Samuel Lidén Borell <samuel@kodafritt.se>
+Tatiana Merkulova <merkulova@google.com>
+Vladimir Rutsky <vladimir@rutsky.org>
+Ximin Luo <infinity0@gmx.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -50,6 +50,7 @@ Pascal Leroy <phl@google.com>
 Paul Hadfield <hadfieldp@google.com> <paul@phad.org.uk>
 Paul Lietar <lietar@google.com>
 Pavel Kalinnikov <pkalinnikov@google.com> <pavelkalinnikov@gmail.com>
+Philippe Boneff <phb@google.com>
 Pierre Phaneuf <pphaneuf@google.com>
 Rob Percival <robpercival@google.com>
 Rob Stradling <rob@comodo.com>


### PR DESCRIPTION
Copied from https://github.com/google/certificate-transparency-go/, and add myself as a contributor.