### PR TITLE
Support GCP KMS for checkpoint signer

### DIFF
--- a/cmd/gcp/kms.go
+++ b/cmd/gcp/kms.go
@@ -1,0 +1,123 @@
+// Copyright 2024 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	"cloud.google.com/go/kms/apiv1/kmspb"
+)
+
+// Signer is a GCP KMS implementation of
+// [crypto signer](https://pkg.go.dev/crypto#Signer).
+type Signer struct {
+	// ctx must be stored because Signer is used as an implementation of the
+	// crypto.Signer interface, which does not allow for a context in the Sign
+	// method. However, the KMS AsymmetricSign API requires a context.
+	ctx       context.Context
+	client    *kms.KeyManagementClient
+	keyName   string
+	publicKey crypto.PublicKey
+}
+
+// Public returns the public key stored in the Signer object.
+func (s *Signer) Public() crypto.PublicKey {
+	return s.publicKey
+}
+
+// Sign signs the digest using the KMS signing key remotely on GCP.
+// Only crypto.SHA256 is supported.
+func (s *Signer) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	// Verify hash function and digest bytes length.
+	if opts == nil || opts.HashFunc() != crypto.SHA256 {
+		return nil, fmt.Errorf("unsupported hash func: %v", opts.HashFunc())
+	}
+	if len(digest) != opts.HashFunc().Size() {
+		return nil, fmt.Errorf("digest bytes length %d does not match hash function bytes length %d", len(digest), opts.HashFunc().Size())
+	}
+
+	// Build the signing request and call the remote signing.
+	req := &kmspb.AsymmetricSignRequest{
+		Name: s.keyName,
+		Digest: &kmspb.Digest{
+			Digest: &kmspb.Digest_Sha256{
+				Sha256: digest,
+			},
+		},
+	}
+	resp, err := s.client.AsymmetricSign(s.ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign data: %w", err)
+	}
+
+	// Perform integrity verification on result.
+	if resp.Name != s.keyName {
+		return nil, fmt.Errorf("request corrupted in-transit: %w", err)
+	}
+
+	return resp.GetSignature(), nil
+}
+
+// NewKMSSigner creates a new signer that uses GCP KMS to sign digests.
+func NewKMSSigner(ctx context.Context, keyName string) (*Signer, error) {
+	kmClient, err := kms.NewKeyManagementClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create KeyManagementClient: %w", err)
+	}
+
+	// Retrieve the public key from GCP KMS
+	req := &kmspb.GetPublicKeyRequest{
+		Name: keyName,
+	}
+	resp, err := kmClient.GetPublicKey(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	pemBlock, rest := pem.Decode([]byte(resp.Pem))
+	if pemBlock == nil {
+		return nil, errors.New("failed to decode PEM")
+	}
+	if len(rest) > 0 {
+		return nil, fmt.Errorf("extra data after decoding PEM: %v", rest)
+	}
+
+	var publicKey crypto.PublicKey
+	switch pemBlock.Type {
+	case "PUBLIC KEY":
+		publicKey, err = x509.ParsePKIXPublicKey(pemBlock.Bytes)
+	case "RSA PUBLIC KEY":
+		publicKey, err = x509.ParsePKCS1PublicKey(pemBlock.Bytes)
+	default:
+		return nil, fmt.Errorf("unsupported PEM type: %s", pemBlock.Type)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &Signer{
+		ctx:       ctx,
+		client:    kmClient,
+		keyName:   keyName,
+		publicKey: publicKey,
+	}, nil
+}

--- a/config.go
+++ b/config.go
@@ -16,6 +16,8 @@ package sctfe
 
 import (
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
 	"errors"
 	"fmt"
 	"strings"
@@ -32,7 +34,6 @@ type ValidatedLogConfig struct {
 	// is also its submission prefix, as per https://c2sp.org/static-ct-api.
 	Origin string
 	// Used to sign the checkpoint and SCTs.
-	// TODO(phboneff): check that this is RSA or ECDSA only.
 	Signer crypto.Signer
 	// If set, ExtKeyUsages will restrict the set of such usages that the
 	// server will accept. By default all are accepted. The values specified
@@ -88,6 +89,16 @@ func ValidateLogConfig(origin string, projectID string, bucket string, spannerDB
 
 	if rootsPemFile == "" {
 		return nil, errors.New("empty rootsPemFile")
+	}
+
+	// Validate signer that only RSA or ECDSA are supported.
+	if signer == nil {
+		return nil, errors.New("empty signer")
+	}
+	switch keyType := signer.Public().(type) {
+	case *rsa.PublicKey, *ecdsa.PublicKey:
+	default:
+		return nil, fmt.Errorf("unsupported key type: %v", keyType)
 	}
 
 	lExtKeyUsages := []string{}

--- a/deployment/live/gcp/test/.terraform.lock.hcl
+++ b/deployment/live/gcp/test/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.1.0"
+  constraints = "6.1.0"
+  hashes = [
+    "h1:okppWOAoIPz45VkydzAA74HRLgEKvP4CFXypPU228j8=",
+    "zh:2463510438c97c59e06ab1fb1ef76221c844abd1bc404c439401fc256e9928ab",
+    "zh:2afd9b76a81c51632bd54d3cc3bdc2685e8d89b8ace8ca7578b1ae42880228b5",
+    "zh:51e2fb64c7c8258ac0ec7315d488e5c655b392bf565f9bee2922ee72f6abfb90",
+    "zh:85aa39bad51132810ee6cd369f426614abff59cb0274fc737d087c17afa9b5ee",
+    "zh:989669bfed5ca7bf4d960eb9f27a62cbe2578ca2907da7c74fc93edae9a497fa",
+    "zh:a26665782e90ef3fd322d6a23a1de383c81ae93395e7c2bd9648a1aa85c69876",
+    "zh:d5e1b785b4c8569b91153eeba89280ffbbe7a0aaabb708833ada67544aeed057",
+    "zh:d748c69eab6acc4ab7ec369b3bd3ddd5d2e4120d99570743dafde74934959a20",
+    "zh:eb853ab5c4c0d3e536b8c77abf844b7893ac355967c95b6e0d39b12526e67989",
+    "zh:f4b50f0ae082412ba189041b6ac540523b7d6463905fed63be67eec03e1539b9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f6e7adcfafe267d9c657a6c087388f7e0c1e3be4dc179a9a823f75c830a499b7",
+  ]
+}

--- a/deployment/live/gcp/test/README.md
+++ b/deployment/live/gcp/test/README.md
@@ -39,12 +39,13 @@ Terraforming the project can be done by:
  2. Run `terragrunt apply`
 
 ## Run the SCTFE
+
 ### With fake chains
 
 On the VM, run the following command to bring up the SCTFE:
 
 ```bash
-go run ./cmd/gcp/ --project_id=${GOOGLE_PROJECT} --bucket=${GOOGLE_PROJECT}-${TESSERA_BASE_NAME}-bucket --spanner_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-db --spanner_dedup_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-dedup-db --private_key=./testdata/ct-http-server.privkey.pem  --password=dirk --roots_pem_file=./testdata/fake-ca.cert --origin=${TESSERA_BASE_NAME}
+go run ./cmd/gcp/ --project_id=${GOOGLE_PROJECT} --bucket=${GOOGLE_PROJECT}-${TESSERA_BASE_NAME}-bucket --spanner_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-db --spanner_dedup_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-dedup-db --private_key=./testdata/ct-http-server.privkey.pem  --password=dirk --roots_pem_file=./testdata/fake-ca.cert --origin=${TESSERA_BASE_NAME} --kms_key=projects/${GOOGLE_PROJECT}/locations/global/keyRings/${TESSERA_BASE_NAME}/cryptoKeys/sctfe-p256-sha256/cryptoKeyVersions/1
 ```
 
 In a different terminal you can either mint and submit certificates manually, or
@@ -116,7 +117,7 @@ Run the SCTFE with the same roots:
 
 ```bash
 cd ${SCTFE_REPO}
-go run ./cmd/gcp/ --project_id=${GOOGLE_PROJECT} --bucket=${GOOGLE_PROJECT}-${TESSERA_BASE_NAME}-bucket --spanner_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-db --private_key=./testdata/ct-http-server.privkey.pem  --password=dirk --roots_pem_file=/tmp/hammercfg/roots.pem --origin=${TESSERA_BASE_NAME} --spanner_dedup_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-dedup-db -v=3
+go run ./cmd/gcp/ --project_id=${GOOGLE_PROJECT} --bucket=${GOOGLE_PROJECT}-${TESSERA_BASE_NAME}-bucket --spanner_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-db --roots_pem_file=/tmp/hammercfg/roots.pem --origin=${TESSERA_BASE_NAME} --spanner_dedup_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-dedup-db --kms_key=projects/${GOOGLE_PROJECT}/locations/global/keyRings/${TESSERA_BASE_NAME}/cryptoKeys/sctfe-p256-sha256/cryptoKeyVersions/1 -v=3
 ```
 
 Run `ct_hammer` in a different terminal:

--- a/deployment/modules/gcp/storage/main.tf
+++ b/deployment/modules/gcp/storage/main.tf
@@ -65,3 +65,27 @@ resource "google_spanner_database" "dedup_db" {
     "CREATE TABLE IDSeq (id INT64 NOT NULL, h BYTES(MAX) NOT NULL, idx INT64 NOT NULL,) PRIMARY KEY (id, h)",
   ]
 }
+
+# KMS
+
+resource "google_kms_key_ring" "sctfe-keyring" {
+  name     = var.base_name
+  location = var.kms_location
+}
+
+resource "google_kms_crypto_key" "sctfe-asymmetric-sign-key-p256-sha256" {
+  name     = "sctfe-p256-sha256"
+  key_ring = google_kms_key_ring.sctfe-keyring.id
+  purpose  = "ASYMMETRIC_SIGN"
+
+  version_template {
+    algorithm        = "EC_SIGN_P256_SHA256"
+    protection_level = "SOFTWARE"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  depends_on = [google_kms_key_ring.sctfe-keyring]
+}

--- a/deployment/modules/gcp/storage/outputs.tf
+++ b/deployment/modules/gcp/storage/outputs.tf
@@ -17,3 +17,8 @@ output "dedup_spanner_db" {
   description = "Dedup Spanner database"
   value       = google_spanner_database.dedup_db
 }
+
+output "kms_key" {
+  description = "KMS asymmetric sign key (P256_SHA256)"
+  value       = google_kms_crypto_key.sctfe-asymmetric-sign-key-p256-sha256
+}

--- a/deployment/modules/gcp/storage/variables.tf
+++ b/deployment/modules/gcp/storage/variables.tf
@@ -12,3 +12,9 @@ variable "location" {
   description = "Location in which to create resources"
   type        = string
 }
+
+variable "kms_location" {
+  type        = string
+  description = "Location of KMS keyring"
+  default     = "global"
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/transparency-dev/static-ct
 go 1.23.1
 
 require (
+	cloud.google.com/go/kms v1.20.0
 	cloud.google.com/go/spanner v1.71.0
 	cloud.google.com/go/storage v1.46.0
 	github.com/golang/mock v1.6.0
@@ -30,6 +31,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.5 // indirect
 	cloud.google.com/go/compute/metadata v0.5.2 // indirect
 	cloud.google.com/go/iam v1.2.1 // indirect
+	cloud.google.com/go/longrunning v0.6.1 // indirect
 	cloud.google.com/go/monitoring v1.21.1 // indirect
 	cloud.google.com/go/trace v1.11.1 // indirect
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -340,6 +340,8 @@ cloud.google.com/go/kms v1.8.0/go.mod h1:4xFEhYFqvW+4VMELtZyxomGSYtSQKzM178ylFW4
 cloud.google.com/go/kms v1.9.0/go.mod h1:qb1tPTgfF9RQP8e1wq4cLFErVuTJv7UsSC915J8dh3w=
 cloud.google.com/go/kms v1.10.0/go.mod h1:ng3KTUtQQU9bPX3+QGLsflZIHlkbn8amFAMY63m8d24=
 cloud.google.com/go/kms v1.10.1/go.mod h1:rIWk/TryCkR59GMC3YtHtXeLzd634lBbKenvyySAyYI=
+cloud.google.com/go/kms v1.20.0 h1:uKUvjGqbBlI96xGE669hcVnEMw1Px/Mvfa62dhM5UrY=
+cloud.google.com/go/kms v1.20.0/go.mod h1:/dMbFF1tLLFnQV44AoI2GlotbjowyUfgVwezxW291fM=
 cloud.google.com/go/language v1.4.0/go.mod h1:F9dRpNFQmJbkaop6g0JhSBXCNlO90e1KWx5iDdxbWic=
 cloud.google.com/go/language v1.6.0/go.mod h1:6dJ8t3B+lUYfStgls25GusK04NLh3eDLQnWM3mdEbhI=
 cloud.google.com/go/language v1.7.0/go.mod h1:DJ6dYN/W+SQOjF8e1hLQXMF21AkH2w9wiPzPCJa2MIE=


### PR DESCRIPTION
#6 

This pull request adds the GCP KMS signer for signing checkpoints and SCTs. The terraform configs are included. Note that it is impossible to immediately remove the keyring and corresponding keys once they're created.

This implementation uses remote signing on GCP KMS. The KMS signing QPS is high enough (60,000) that it is very hard to hit the limit. There is [some cost incurred for each signing operation](https://cloud.google.com/kms/pricing).