### PR TITLE
Add Terraform and Terragrunt into `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,18 @@ go.work.sum
 
 # Project IDX
 .idx/
+
+# Terraform
+
+## Local .terraform directories
+**/.terraform/*
+
+## .tfstate files
+*.tfstate
+*.tfstate.*
+
+## Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Terragrunt
+.terragrunt-cache


### PR DESCRIPTION
The list comes from the [Terraform Style Guide](https://developer.hashicorp.com/terraform/language/style#gitignore) and [Terragrunt live example](https://github.com/gruntwork-io/terragrunt-infrastructure-live-example/blob/master/.gitignore).