### PR TITLE
Enable Artifact Registry in GCP CI Conformance Terraform

### DIFF
--- a/deployment/live/gcp/ci/README.md
+++ b/deployment/live/gcp/ci/README.md
@@ -30,8 +30,6 @@ export GOOGLE_REGION={VALUE} # e.g: us-central1
 unset TESSERA_BASE_NAME
 ```
 
-TODO: Add the Artifact Registry which is in the Cloud Build pull request. The expected repository is `${GOOGLE_REGION}-docker.pkg.dev/${GOOGLE_PROJECT}/docker-ci`.
-
 Build and push the Docker image to Artifact Registry repository:
 
 ```sh
@@ -45,4 +43,3 @@ docker push ${GOOGLE_REGION}-docker.pkg.dev/${GOOGLE_PROJECT}/docker-ci/conforma
 Terraforming the project can be done by:
   1. `cd` to the relevant directory (deployment/live/gcp/ci/) for the environment to deploy/change.
   2. Run `terragrunt apply`.
-

--- a/deployment/live/gcp/ci/terragrunt.hcl
+++ b/deployment/live/gcp/ci/terragrunt.hcl
@@ -4,6 +4,7 @@ terraform {
 
 locals {
   env                 = "ci"
+  docker_env          = local.env
   base_name           = "${local.env}-conformance"
   server_docker_image = "us-central1-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/conformance-gcp:latest"
 }

--- a/deployment/modules/gcp/artifactregistry/main.tf
+++ b/deployment/modules/gcp/artifactregistry/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "registry.terraform.io/hashicorp/google"
+      version = "6.1.0"
+    }
+  }
+}
+
+# Artifact Registry
+
+resource "google_project_service" "artifact_registry_api" {
+  service            = "artifactregistry.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_artifact_registry_repository" "docker" {
+  repository_id = "docker-${var.docker_env}"
+  location      = var.location
+  description   = "Static CT docker images"
+  format        = "DOCKER"
+  depends_on = [
+    google_project_service.artifact_registry_api,
+  ]
+}

--- a/deployment/modules/gcp/artifactregistry/variables.tf
+++ b/deployment/modules/gcp/artifactregistry/variables.tf
@@ -1,0 +1,9 @@
+variable "location" {
+  description = "Location in which to create resources"
+  type        = string
+}
+
+variable "docker_env" {
+  description = "Unique identifier for the Docker env, e.g. dev or ci or prod"
+  type        = string
+}

--- a/deployment/modules/gcp/cloudbuild/main.tf
+++ b/deployment/modules/gcp/cloudbuild/main.tf
@@ -11,19 +11,11 @@ terraform {
 
 # Artifact Registry
 
-resource "google_project_service" "artifact_registry_api" {
-  service            = "artifactregistry.googleapis.com"
-  disable_on_destroy = false
-}
+module "artifactregistry" {
+  source = "../artifactregistry"
 
-resource "google_artifact_registry_repository" "docker" {
-  repository_id = "docker-${var.docker_env}"
-  location      = var.location
-  description   = "Static CT docker images"
-  format        = "DOCKER"
-  depends_on = [
-    google_project_service.artifact_registry_api,
-  ]
+  location   = var.location
+  docker_env = var.docker_env
 }
 
 # Cloud Build

--- a/deployment/modules/gcp/conformance/main.tf
+++ b/deployment/modules/gcp/conformance/main.tf
@@ -2,6 +2,13 @@ terraform {
   backend "gcs" {}
 }
 
+module "artifactregistry" {
+  source = "../artifactregistry"
+
+  location   = var.location
+  docker_env = var.docker_env
+}
+
 module "storage" {
   source = "../storage"
 

--- a/deployment/modules/gcp/conformance/variables.tf
+++ b/deployment/modules/gcp/conformance/variables.tf
@@ -18,6 +18,11 @@ variable "env" {
   type        = string
 }
 
+variable "docker_env" {
+  description = "Unique identifier for the Docker env, e.g. dev or ci or prod"
+  type        = string
+}
+
 variable "server_docker_image" {
   description = "The full image URL (path & tag) for the Docker image to deploy in Cloud Run"
   type        = string


### PR DESCRIPTION
Towards #53.

This PR implements the TODO for "deployment/live/gcp/ci/", so the Artifact Registry does not need to be created externally.