### PR TITLE
Disable GCP Spanner backup in storage module

### DIFF
--- a/deployment/modules/gcp/storage/main.tf
+++ b/deployment/modules/gcp/storage/main.tf
@@ -46,6 +46,7 @@ resource "google_spanner_instance" "log_spanner" {
   config           = "regional-${var.location}"
   display_name     = var.base_name
   processing_units = 100
+  default_backup_schedule_type = "NONE"
 
   force_destroy = var.ephemeral
 }


### PR DESCRIPTION
Towards #53. The Spanner backup blocks the instance from being destroyed.