### PR TITLE
Parse GCP flags in the GCP binary

### DIFF
--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -201,11 +201,11 @@ func awaitSignal(doneFn func()) {
 }
 
 func newGCPStorage(ctx context.Context, signer note.Signer) (*sctfe.CTStorage, error) {
-	if len(*bucket) == 0 {
+	if *bucket == "" {
 		return nil, errors.New("missing bucket")
 	}
 
-	if len(*spannerDB) == 0 {
+	if *spannerDB == "" {
 		return nil, errors.New("missing spannerDB")
 	}
 

--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -85,7 +85,7 @@ func main() {
 		klog.Exitf("Can't create secret manager signer: %v", err)
 	}
 
-	vCfg, err := sctfe.ValidateLogConfig(*origin, *projectID, *bucket, *spannerDB, *rootsPemFile, *rejectExpired, *rejectUnexpired, *extKeyUsages, *rejectExtensions, notAfterStart.t, notAfterLimit.t, signer)
+	vCfg, err := sctfe.ValidateLogConfig(*origin, *rootsPemFile, *rejectExpired, *rejectUnexpired, *extKeyUsages, *rejectExtensions, notAfterStart.t, notAfterLimit.t, signer)
 	if err != nil {
 		klog.Exitf("Invalid config: %v", err)
 	}

--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -58,7 +58,6 @@ var (
 	tracingProjectID           = flag.String("tracing_project_id", "", "project ID to pass to stackdriver. Can be empty for GCP, consult docs for other platforms.")
 	tracingPercent             = flag.Int("tracing_percent", 0, "Percent of requests to be traced. Zero is a special case to use the DefaultSampler.")
 	origin                     = flag.String("origin", "", "Origin of the log, for checkpoints and the monitoring prefix.")
-	projectID                  = flag.String("project_id", "", "GCP ProjectID.")
 	bucket                     = flag.String("bucket", "", "Name of the bucket to store the log in.")
 	spannerDB                  = flag.String("spanner_db_path", "", "Spanner database path: projects/{projectId}/instances/{instanceId}/databases/{databaseId}.")
 	spannerDedupDB             = flag.String("spanner_dedup_db_path", "", "Spanner deduplication database path: projects/{projectId}/instances/{instanceId}/databases/{databaseId}.")
@@ -214,7 +213,7 @@ func newGCPStorage(ctx context.Context, signer note.Signer) (*sctfe.CTStorage, e
 		return nil, fmt.Errorf("Failed to initialize GCP Tessera storage: %v", err)
 	}
 
-	issuerStorage, err := gcpSCTFE.NewIssuerStorage(ctx, *projectID, *bucket, "fingerprints/", "application/pkix-cert")
+	issuerStorage, err := gcpSCTFE.NewIssuerStorage(ctx, *bucket, "fingerprints/", "application/pkix-cert")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to initialize GCP issuer storage: %v", err)
 	}

--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -75,6 +76,9 @@ func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
 	ctx := context.Background()
+	if err := validateFlags(); err != nil {
+		klog.Exitf("Invalid flags: %v", err)
+	}
 
 	signer, err := NewSecretManagerSigner(ctx, *signerPublicKeySecretName, *signerPrivateKeySecretName)
 	if err != nil {
@@ -243,5 +247,20 @@ func (t *timestampFlag) Set(w string) error {
 		return fmt.Errorf("can't parse %q as RFC3339 timestamp: %v", w, err)
 	}
 	t.t = &tt
+	return nil
+}
+
+func validateFlags() error {
+	if len(*projectID) == 0 {
+		return errors.New("missing projectID")
+	}
+
+	if len(*bucket) == 0 {
+		return errors.New("missing bucket")
+	}
+
+	if len(*spannerDB) == 0 {
+		return errors.New("missing spannerDB")
+	}
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -73,19 +73,6 @@ func ValidateLogConfig(origin string, projectID string, bucket string, spannerDB
 		return nil, errors.New("empty origin")
 	}
 
-	// TODO(phboneff): move this logic together with the tests out of config.go and validate the flags directly
-	if projectID == "" {
-		return nil, errors.New("empty projectID")
-	}
-
-	if bucket == "" {
-		return nil, errors.New("empty bucket")
-	}
-
-	if spannerDB == "" {
-		return nil, errors.New("empty spannerDB")
-	}
-
 	if rootsPemFile == "" {
 		return nil, errors.New("empty rootsPemFile")
 	}

--- a/config.go
+++ b/config.go
@@ -68,7 +68,7 @@ type ValidatedLogConfig struct {
 //   - Merge delays (if present) are correct.
 //
 // Returns the validated structures (useful to avoid double validation).
-func ValidateLogConfig(origin string, projectID string, bucket string, spannerDB string, rootsPemFile string, rejectExpired bool, rejectUnexpired bool, extKeyUsages string, rejectExtensions string, notAfterStart *time.Time, notAfterLimit *time.Time, signer crypto.Signer) (*ValidatedLogConfig, error) {
+func ValidateLogConfig(origin string, rootsPemFile string, rejectExpired bool, rejectUnexpired bool, extKeyUsages string, rejectExtensions string, notAfterStart *time.Time, notAfterLimit *time.Time, signer crypto.Signer) (*ValidatedLogConfig, error) {
 	if origin == "" {
 		return nil, errors.New("empty origin")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -55,33 +55,6 @@ func TestValidateLogConfig(t *testing.T) {
 			spannerDB: "spanner",
 		},
 		{
-			desc:      "empty-projectID",
-			wantErr:   "empty projectID",
-			origin:    "testlog",
-			projectID: "",
-			bucket:    "bucket",
-			spannerDB: "spanner",
-			signer:    signer,
-		},
-		{
-			desc:      "empty-bucket",
-			wantErr:   "empty bucket",
-			origin:    "testlog",
-			projectID: "project",
-			bucket:    "",
-			spannerDB: "spanner",
-			signer:    signer,
-		},
-		{
-			desc:      "empty-spannerDB",
-			wantErr:   "empty spannerDB",
-			origin:    "testlog",
-			projectID: "project",
-			bucket:    "bucket",
-			spannerDB: "",
-			signer:    signer,
-		},
-		{
 			desc:      "empty-rootsPemFile",
 			wantErr:   "empty rootsPemFile",
 			origin:    "testlog",
@@ -199,7 +172,7 @@ func TestValidateLogConfig(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			vc, err := ValidateLogConfig(tc.origin, tc.projectID, tc.bucket, tc.spannerDB, tc.rootsPemFile, tc.rejectExpired, tc.rejectUnexpired, tc.extKeyUsages, "", tc.notAfterStart, tc.notAfterLimit, signer)
+			vc, err := ValidateLogConfig(tc.origin, tc.rootsPemFile, tc.rejectExpired, tc.rejectUnexpired, tc.extKeyUsages, "", tc.notAfterStart, tc.notAfterLimit, signer)
 			if len(tc.wantErr) == 0 && err != nil {
 				t.Errorf("ValidateLogConfig()=%v, want nil", err)
 			}

--- a/deployment/live/gcp/test/README.md
+++ b/deployment/live/gcp/test/README.md
@@ -54,7 +54,6 @@ On the VM, run the following command to bring up the SCTFE:
 
 ```bash
 go run ./cmd/gcp/ \
-  --project_id=${GOOGLE_PROJECT} \
   --bucket=${GOOGLE_PROJECT}-${TESSERA_BASE_NAME}-bucket \
   --spanner_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-db \
   --spanner_dedup_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-dedup-db \
@@ -144,7 +143,6 @@ Run the SCTFE with the same roots:
 ```bash
 cd ${SCTFE_REPO}
 go run ./cmd/gcp/ \
-  --project_id=${GOOGLE_PROJECT} \
   --bucket=${GOOGLE_PROJECT}-${TESSERA_BASE_NAME}-bucket \
   --spanner_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-db \
   --roots_pem_file=/tmp/hammercfg/roots.pem \

--- a/instance_test.go
+++ b/instance_test.go
@@ -111,9 +111,6 @@ func TestSetUpInstance(t *testing.T) {
 		{
 			desc:         "missing-create-storage",
 			origin:       "log",
-			projectID:    "project",
-			bucket:       "bucket",
-			spannerDB:    "spanner",
 			rootsPemFile: "./testdata/fake-ca.cert",
 			signer:       signer,
 			wantErr:      "failed to initiate storage backend",
@@ -121,9 +118,6 @@ func TestSetUpInstance(t *testing.T) {
 		{
 			desc:         "failing-create-storage",
 			origin:       "log",
-			projectID:    "project",
-			bucket:       "bucket",
-			spannerDB:    "spanner",
 			rootsPemFile: "./testdata/fake-ca.cert",
 			signer:       signer,
 			ctStorage: func(_ context.Context, _ note.Signer) (*CTStorage, error) {

--- a/instance_test.go
+++ b/instance_test.go
@@ -45,9 +45,6 @@ func TestSetUpInstance(t *testing.T) {
 	var tests = []struct {
 		desc             string
 		origin           string
-		projectID        string
-		bucket           string
-		spannerDB        string
 		rootsPemFile     string
 		extKeyUsages     string
 		rejectExtensions string
@@ -58,9 +55,6 @@ func TestSetUpInstance(t *testing.T) {
 		{
 			desc:         "valid",
 			origin:       "log",
-			projectID:    "project",
-			bucket:       "bucket",
-			spannerDB:    "spanner",
 			rootsPemFile: "./testdata/fake-ca.cert",
 			ctStorage:    fakeCTStorage,
 			signer:       signer,
@@ -68,9 +62,6 @@ func TestSetUpInstance(t *testing.T) {
 		{
 			desc:         "no-roots",
 			origin:       "log",
-			projectID:    "project",
-			bucket:       "bucket",
-			spannerDB:    "spanner",
 			rootsPemFile: "./testdata/nofile",
 			ctStorage:    fakeCTStorage,
 			wantErr:      "failed to read trusted roots",
@@ -79,9 +70,6 @@ func TestSetUpInstance(t *testing.T) {
 		{
 			desc:         "missing-root-cert",
 			origin:       "log",
-			projectID:    "project",
-			bucket:       "bucket",
-			spannerDB:    "spanner",
 			ctStorage:    fakeCTStorage,
 			rootsPemFile: "./testdata/bogus.cert",
 			signer:       signer,
@@ -90,9 +78,6 @@ func TestSetUpInstance(t *testing.T) {
 		{
 			desc:         "valid-ekus-1",
 			origin:       "log",
-			projectID:    "project",
-			bucket:       "bucket",
-			spannerDB:    "spanner",
 			rootsPemFile: "./testdata/fake-ca.cert",
 			extKeyUsages: "Any",
 			signer:       signer,
@@ -101,9 +86,6 @@ func TestSetUpInstance(t *testing.T) {
 		{
 			desc:         "valid-ekus-2",
 			origin:       "log",
-			projectID:    "project",
-			bucket:       "bucket",
-			spannerDB:    "spanner",
 			rootsPemFile: "./testdata/fake-ca.cert",
 			extKeyUsages: "Any,ServerAuth,TimeStamping",
 			signer:       signer,
@@ -112,9 +94,6 @@ func TestSetUpInstance(t *testing.T) {
 		{
 			desc:             "valid-reject-ext",
 			origin:           "log",
-			projectID:        "project",
-			bucket:           "bucket",
-			spannerDB:        "spanner",
 			rootsPemFile:     "./testdata/fake-ca.cert",
 			rejectExtensions: "1.2.3.4,5.6.7.8",
 			signer:           signer,
@@ -123,9 +102,6 @@ func TestSetUpInstance(t *testing.T) {
 		{
 			desc:             "invalid-reject-ext",
 			origin:           "log",
-			projectID:        "project",
-			bucket:           "bucket",
-			spannerDB:        "spanner",
 			ctStorage:        fakeCTStorage,
 			rootsPemFile:     "./testdata/fake-ca.cert",
 			rejectExtensions: "1.2.3.4,one.banana.two.bananas",
@@ -159,7 +135,7 @@ func TestSetUpInstance(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			vCfg, err := ValidateLogConfig(test.origin, test.projectID, test.bucket, test.spannerDB, test.rootsPemFile, false, false, test.extKeyUsages, test.rejectExtensions, nil, nil, signer)
+			vCfg, err := ValidateLogConfig(test.origin, test.rootsPemFile, false, false, test.extKeyUsages, test.rejectExtensions, nil, nil, signer)
 			if err != nil {
 				t.Fatalf("ValidateLogConfig(): %v", err)
 			}
@@ -205,9 +181,6 @@ func TestSetUpInstanceSetsValidationOpts(t *testing.T) {
 	var tests = []struct {
 		desc          string
 		origin        string
-		projectID     string
-		bucket        string
-		spannerDB     string
 		rootsPemFile  string
 		notAfterStart *time.Time
 		notAfterLimit *time.Time
@@ -216,27 +189,18 @@ func TestSetUpInstanceSetsValidationOpts(t *testing.T) {
 		{
 			desc:         "no validation opts",
 			origin:       "log",
-			projectID:    "project",
-			bucket:       "bucket",
-			spannerDB:    "spanner",
 			rootsPemFile: "./testdata/fake-ca.cert",
 			signer:       signer,
 		},
 		{
 			desc:          "notAfterStart only",
 			origin:        "log",
-			projectID:     "project",
-			bucket:        "bucket",
-			spannerDB:     "spanner",
 			rootsPemFile:  "./testdata/fake-ca.cert",
 			notAfterStart: &start,
 		},
 		{
 			desc:          "notAfter range",
 			origin:        "log",
-			projectID:     "project",
-			bucket:        "bucket",
-			spannerDB:     "spanner",
 			rootsPemFile:  "./testdata/fake-ca.cert",
 			notAfterStart: &start,
 			notAfterLimit: &limit,
@@ -246,7 +210,7 @@ func TestSetUpInstanceSetsValidationOpts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			vCfg, err := ValidateLogConfig(test.origin, test.projectID, test.bucket, test.spannerDB, test.rootsPemFile, false, false, "", "", test.notAfterStart, test.notAfterLimit, signer)
+			vCfg, err := ValidateLogConfig(test.origin, test.rootsPemFile, false, false, "", "", test.notAfterStart, test.notAfterLimit, signer)
 			if err != nil {
 				t.Fatalf("ValidateLogConfig(): %v", err)
 			}

--- a/storage/gcp/issuers.go
+++ b/storage/gcp/issuers.go
@@ -36,7 +36,7 @@ type IssuersStorage struct {
 // NewIssuerStorage creates a new GCSStorage.
 //
 // The specified bucket must exist or an error will be returned.
-func NewIssuerStorage(ctx context.Context, projectID string, bucket string, prefix string, contentType string) (*IssuersStorage, error) {
+func NewIssuerStorage(ctx context.Context, bucket string, prefix string, contentType string) (*IssuersStorage, error) {
 	c, err := gcs.NewClient(ctx, gcs.WithJSONReads())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GCS client: %v", err)


### PR DESCRIPTION
Towards #5

This PR moves GCP flags parsing to the GCP binary. It also removes the `projectID` flag, which is not used anymore.