### PR TITLE
Cleanup: renames and delete unused file

### DIFF
--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -52,7 +52,7 @@ var (
 
 	httpEndpoint               = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
 	metricsEndpoint            = flag.String("metrics_endpoint", "", "Endpoint for serving metrics; if left empty, metrics will be visible on --http_endpoint.")
-	tesseraDeadline            = flag.Duration("tessera_deadline", time.Second*10, "Deadline for Tessera requests.")
+	httpDeadline               = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
 	maskInternalErrors         = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
 	tracing                    = flag.Bool("tracing", false, "If true opencensus Stackdriver tracing will be enabled. See https://opencensus.io/.")
 	tracingProjectID           = flag.String("tracing_project_id", "", "project ID to pass to stackdriver. Can be empty for GCP, consult docs for other platforms.")
@@ -104,7 +104,7 @@ func main() {
 	// Register handlers for all the configured logs.
 	opts := sctfe.InstanceOptions{
 		Validated:          vCfg,
-		Deadline:           *tesseraDeadline,
+		Deadline:           *httpDeadline,
 		MetricFactory:      prometheus.MetricFactory{},
 		RequestLog:         new(sctfe.DefaultRequestLog),
 		MaskInternalErrors: *maskInternalErrors,

--- a/handlers.go
+++ b/handlers.go
@@ -111,6 +111,7 @@ func (a AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rspLatency.Observe(latency, label0, label1, strconv.Itoa(statusCode))
 	}()
 	klog.V(2).Infof("%s: request %v %q => %s", a.Info.Origin, r.Method, r.URL, a.Name)
+	// TODO(phboneff): add a.Method directly on the handler path and remove this test.
 	if r.Method != a.Method {
 		klog.Warningf("%s: %s wrong HTTP method: %v", a.Info.Origin, a.Name, r.Method)
 		a.Info.SendHTTPError(w, http.StatusMethodNotAllowed, fmt.Errorf("method not allowed: %s", r.Method))

--- a/handlers.go
+++ b/handlers.go
@@ -416,7 +416,7 @@ func getRoots(_ context.Context, li *logInfo, w http.ResponseWriter, _ *http.Req
 	return http.StatusOK, nil
 }
 
-// deadlineTime calculates the future time an RPC should expire based on our config
+// deadlineTime calculates the future time a request should expire based on our config.
 func deadlineTime(li *logInfo) time.Time {
 	return li.TimeSource.Now().Add(li.instanceOpts.Deadline)
 }

--- a/instance.go
+++ b/instance.go
@@ -35,7 +35,7 @@ type InstanceOptions struct {
 	Validated *ValidatedLogConfig
 	// CreateStorage instantiates a Tessera storage implementation with a signer option.
 	CreateStorage func(context.Context, note.Signer) (*CTStorage, error)
-	// Deadline is a timeout for Tessera requests.
+	// Deadline is a timeout for HTTP requests.
 	Deadline time.Duration
 	// MetricFactory allows creating metrics.
 	MetricFactory monitoring.MetricFactory

--- a/proto_gen.go
+++ b/proto_gen.go
@@ -1,6 +1,0 @@
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-package sctfe
-
-//go:generate sh -c "protoc -I=. -I$(go list -f '{{ .Dir }}' github.com/google/trillian) -I$(go list -f '{{ .Dir }}' github.com/transparency-dev/static-ct) --go_out=paths=source_relative:. configpb/config.proto"

--- a/requestlog.go
+++ b/requestlog.go
@@ -38,8 +38,8 @@ type RequestLog interface {
 	// The returned context should be used in all the following calls to
 	// this API. This is normally arranged by the request handler code.
 	Start(context.Context) context.Context
-	// LogOrigin will be called once per request to set the log prefix.
-	LogOrigin(context.Context, string)
+	// Origin will be called once per request to set the log prefix.
+	Origin(context.Context, string)
 	// AddDERToChain will be called once for each certificate in a submitted
 	// chain. It's called early in request processing so the supplied bytes
 	// have not been checked for validity. Calls will be in order of the
@@ -71,8 +71,8 @@ func (dlr *DefaultRequestLog) Start(ctx context.Context) context.Context {
 	return ctx
 }
 
-// LogOrigin logs the origin of the CT log that this request is for.
-func (dlr *DefaultRequestLog) LogOrigin(_ context.Context, p string) {
+// Origin logs the origin of the CT log that this request is for.
+func (dlr *DefaultRequestLog) Origin(_ context.Context, p string) {
 	klog.V(vLevel).Infof("RL: LogOrigin: %s", p)
 }
 


### PR DESCRIPTION
Towards #5 

This PR:
 - renames LogOrigin to Origin
 - renames tesseraDeadline to httpDeadline
 - deleted proto_gen.go which is not used anymore