### PR TITLE
Drop dependency on trillian/monitoring

### DIFF
--- a/internal/scti/handlers.go
+++ b/internal/scti/handlers.go
@@ -73,6 +73,7 @@ var (
 
 // setupMetrics initializes all the exported metrics.
 func setupMetrics() {
+	// TODO(phboneff): add metrics for deduplication and chain storage.
 	knownLogs = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "known_logs",

--- a/internal/scti/handlers_test.go
+++ b/internal/scti/handlers_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/trillian/monitoring"
 	"github.com/transparency-dev/static-ct/internal/testdata"
 	"github.com/transparency-dev/static-ct/mockstorage"
 	"github.com/transparency-dev/static-ct/modules/dedup"
@@ -96,10 +95,9 @@ func setupTest(t *testing.T, pemRoots []string, signer crypto.Signer) handlerTes
 	}
 
 	hOpts := HandlerOptions{
-		Deadline:      time.Millisecond * 500,
-		MetricFactory: monitoring.InertMetricFactory{},
-		RequestLog:    new(DefaultRequestLog),
-		TimeSource:    fakeTimeSource,
+		Deadline:   time.Millisecond * 500,
+		RequestLog: new(DefaultRequestLog),
+		TimeSource: fakeTimeSource,
 	}
 	signSCT := func(leaf *ct.MerkleTreeLeaf) (*ct.SignedCertificateTimestamp, error) {
 		return buildV1SCT(signer, leaf)


### PR DESCRIPTION
Towards #105 and #106

This PR makes use of the prometheus library directly, rather than using trillian/monitoring.

It also introduces the following changes:
 - a new `lastSCTIndex` metric since SCTs now include an index
 - changes the `logid` label to `origin`
 - changes the label `ep` label to `op`