### PR TITLE
Drop dependency on c-t-go for x509 util

### DIFF
--- a/ctlog.go
+++ b/ctlog.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/x509"
-	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/transparency-dev/static-ct/internal/scti"
+	"github.com/transparency-dev/static-ct/internal/x509util"
 	"github.com/transparency-dev/static-ct/storage"
 )
 

--- a/internal/scti/chain_validation.go
+++ b/internal/scti/chain_validation.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/x509"
-	"github.com/google/certificate-transparency-go/x509util"
+	"github.com/transparency-dev/static-ct/internal/x509util"
 	"k8s.io/klog/v2"
 )
 

--- a/internal/scti/chain_validation_test.go
+++ b/internal/scti/chain_validation_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509/pkix"
-	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/transparency-dev/static-ct/internal/testdata"
+	"github.com/transparency-dev/static-ct/internal/x509util"
 )
 
 func wipeExtensions(cert *x509.Certificate) *x509.Certificate {

--- a/internal/scti/ctlog_test.go
+++ b/internal/scti/ctlog_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/google/trillian/crypto/keys/pem"
+	"github.com/transparency-dev/static-ct/internal/x509util"
 	"github.com/transparency-dev/static-ct/storage"
 	"golang.org/x/mod/sumdb/note"
 )

--- a/internal/scti/handlers_test.go
+++ b/internal/scti/handlers_test.go
@@ -31,11 +31,11 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/certificate-transparency-go/x509"
-	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/transparency-dev/static-ct/internal/testdata"
 	"github.com/transparency-dev/static-ct/internal/types"
+	"github.com/transparency-dev/static-ct/internal/x509util"
 	"github.com/transparency-dev/static-ct/mockstorage"
 	"github.com/transparency-dev/static-ct/modules/dedup"
 	"github.com/transparency-dev/trillian-tessera/ctonly"

--- a/internal/scti/signatures_test.go
+++ b/internal/scti/signatures_test.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/google/certificate-transparency-go/tls"
 	"github.com/google/certificate-transparency-go/x509"
-	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/transparency-dev/static-ct/internal/testdata"
 	"github.com/transparency-dev/static-ct/internal/types"
+	"github.com/transparency-dev/static-ct/internal/x509util"
 )
 
 var (

--- a/internal/x509util/certs_test.go
+++ b/internal/x509util/certs_test.go
@@ -1,0 +1,339 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package x509util_test
+
+// pemUnknownBlockType is a PEM containing only an empty block of a
+// non-standard type.
+const pemUnknownBlockType = `
+-----BEGIN SOMETHING-----
+-----END SOMETHING-----`
+
+// pemCACertWithOtherStuff is a valid test CA certificate (pemCACert below)
+// with additional blocks surrounding it.
+const pemCACertWithOtherStuff = `
+-----BEGIN SOMETHING-----
+-----END SOMETHING-----
+-----BEGIN CERTIFICATE-----
+MIIC0DCCAjmgAwIBAgIBADANBgkqhkiG9w0BAQUFADBVMQswCQYDVQQGEwJHQjEk
+MCIGA1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENBMQ4wDAYDVQQIEwVX
+YWxlczEQMA4GA1UEBxMHRXJ3IFdlbjAeFw0xMjA2MDEwMDAwMDBaFw0yMjA2MDEw
+MDAwMDBaMFUxCzAJBgNVBAYTAkdCMSQwIgYDVQQKExtDZXJ0aWZpY2F0ZSBUcmFu
+c3BhcmVuY3kgQ0ExDjAMBgNVBAgTBVdhbGVzMRAwDgYDVQQHEwdFcncgV2VuMIGf
+MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDVimhTYhCicRmTbneDIRgcKkATxtB7
+jHbrkVfT0PtLO1FuzsvRyY2RxS90P6tjXVUJnNE6uvMa5UFEJFGnTHgW8iQ8+EjP
+KDHM5nugSlojgZ88ujfmJNnDvbKZuDnd/iYx0ss6hPx7srXFL8/BT/9Ab1zURmnL
+svfP34b7arnRsQIDAQABo4GvMIGsMB0GA1UdDgQWBBRfnYgNyHPmVNT4DdjmsMEk
+tEfDVTB9BgNVHSMEdjB0gBRfnYgNyHPmVNT4DdjmsMEktEfDVaFZpFcwVTELMAkG
+A1UEBhMCR0IxJDAiBgNVBAoTG0NlcnRpZmljYXRlIFRyYW5zcGFyZW5jeSBDQTEO
+MAwGA1UECBMFV2FsZXMxEDAOBgNVBAcTB0VydyBXZW6CAQAwDAYDVR0TBAUwAwEB
+/zANBgkqhkiG9w0BAQUFAAOBgQAGCMxKbWTyIF4UbASydvkrDvqUpdryOvw4BmBt
+OZDQoeojPUApV2lGOwRmYef6HReZFSCa6i4Kd1F2QRIn18ADB8dHDmFYT9czQiRy
+f1HWkLxHqd81TbD26yWVXeGJPE3VICskovPkQNJ0tU4b03YmnKliibduyqQQkOFP
+OwqULg==
+-----END CERTIFICATE-----
+-----BEGIN SOMETHING-----
+-----END SOMETHING-----`
+
+// pemCACert is a valid test CA certificate.
+//
+//	Data:
+//	    Version: 3 (0x2)
+//	    Serial Number: 0 (0x0)
+//	Signature Algorithm: sha1WithRSAEncryption
+//	    Issuer: C=GB, O=Certificate Transparency CA, ST=Wales, L=Erw Wen
+//	    Validity
+//	        Not Before: Jun  1 00:00:00 2012 GMT
+//	        Not After : Jun  1 00:00:00 2022 GMT
+//	    Subject: C=GB, O=Certificate Transparency CA, ST=Wales, L=Erw Wen
+//	    Subject Public Key Info:
+//	        Public Key Algorithm: rsaEncryption
+//	            Public-Key: (1024 bit)
+//	            Modulus:
+//	                00:d5:8a:68:53:62:10:a2:71:19:93:6e:77:83:21:
+//	                18:1c:2a:40:13:c6:d0:7b:8c:76:eb:91:57:d3:d0:
+//	                fb:4b:3b:51:6e:ce:cb:d1:c9:8d:91:c5:2f:74:3f:
+//	                ab:63:5d:55:09:9c:d1:3a:ba:f3:1a:e5:41:44:24:
+//	                51:a7:4c:78:16:f2:24:3c:f8:48:cf:28:31:cc:e6:
+//	                7b:a0:4a:5a:23:81:9f:3c:ba:37:e6:24:d9:c3:bd:
+//	                b2:99:b8:39:dd:fe:26:31:d2:cb:3a:84:fc:7b:b2:
+//	                b5:c5:2f:cf:c1:4f:ff:40:6f:5c:d4:46:69:cb:b2:
+//	                f7:cf:df:86:fb:6a:b9:d1:b1
+//	            Exponent: 65537 (0x10001)
+//	    X509v3 extensions:
+//	        X509v3 Subject Key Identifier:
+//	            5F:9D:88:0D:C8:73:E6:54:D4:F8:0D:D8:E6:B0:C1:24:B4:47:C3:55
+//	        X509v3 Authority Key Identifier:
+//	            keyid:5F:9D:88:0D:C8:73:E6:54:D4:F8:0D:D8:E6:B0:C1:24:B4:47:C3:55
+//	            DirName:/C=GB/O=Certificate Transparency CA/ST=Wales/L=Erw Wen
+//	            serial:00
+//
+//	        X509v3 Basic Constraints:
+//	            CA:TRUE
+//	Signature Algorithm: sha1WithRSAEncryption
+//	     06:08:cc:4a:6d:64:f2:20:5e:14:6c:04:b2:76:f9:2b:0e:fa:
+//	     94:a5:da:f2:3a:fc:38:06:60:6d:39:90:d0:a1:ea:23:3d:40:
+//	     29:57:69:46:3b:04:66:61:e7:fa:1d:17:99:15:20:9a:ea:2e:
+//	     0a:77:51:76:41:12:27:d7:c0:03:07:c7:47:0e:61:58:4f:d7:
+//	     33:42:24:72:7f:51:d6:90:bc:47:a9:df:35:4d:b0:f6:eb:25:
+//	     95:5d:e1:89:3c:4d:d5:20:2b:24:a2:f3:e4:40:d2:74:b5:4e:
+//	     1b:d3:76:26:9c:a9:62:89:b7:6e:ca:a4:10:90:e1:4f:3b:0a:
+//	     94:2e
+const pemCACert = `
+-----BEGIN CERTIFICATE-----
+MIIC0DCCAjmgAwIBAgIBADANBgkqhkiG9w0BAQUFADBVMQswCQYDVQQGEwJHQjEk
+MCIGA1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENBMQ4wDAYDVQQIEwVX
+YWxlczEQMA4GA1UEBxMHRXJ3IFdlbjAeFw0xMjA2MDEwMDAwMDBaFw0yMjA2MDEw
+MDAwMDBaMFUxCzAJBgNVBAYTAkdCMSQwIgYDVQQKExtDZXJ0aWZpY2F0ZSBUcmFu
+c3BhcmVuY3kgQ0ExDjAMBgNVBAgTBVdhbGVzMRAwDgYDVQQHEwdFcncgV2VuMIGf
+MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDVimhTYhCicRmTbneDIRgcKkATxtB7
+jHbrkVfT0PtLO1FuzsvRyY2RxS90P6tjXVUJnNE6uvMa5UFEJFGnTHgW8iQ8+EjP
+KDHM5nugSlojgZ88ujfmJNnDvbKZuDnd/iYx0ss6hPx7srXFL8/BT/9Ab1zURmnL
+svfP34b7arnRsQIDAQABo4GvMIGsMB0GA1UdDgQWBBRfnYgNyHPmVNT4DdjmsMEk
+tEfDVTB9BgNVHSMEdjB0gBRfnYgNyHPmVNT4DdjmsMEktEfDVaFZpFcwVTELMAkG
+A1UEBhMCR0IxJDAiBgNVBAoTG0NlcnRpZmljYXRlIFRyYW5zcGFyZW5jeSBDQTEO
+MAwGA1UECBMFV2FsZXMxEDAOBgNVBAcTB0VydyBXZW6CAQAwDAYDVR0TBAUwAwEB
+/zANBgkqhkiG9w0BAQUFAAOBgQAGCMxKbWTyIF4UbASydvkrDvqUpdryOvw4BmBt
+OZDQoeojPUApV2lGOwRmYef6HReZFSCa6i4Kd1F2QRIn18ADB8dHDmFYT9czQiRy
+f1HWkLxHqd81TbD26yWVXeGJPE3VICskovPkQNJ0tU4b03YmnKliibduyqQQkOFP
+OwqULg==
+-----END CERTIFICATE-----`
+
+// pemCACertDuplicated contains two identical copies of the same test CA cert.
+const pemCACertDuplicated = `
+-----BEGIN CERTIFICATE-----
+MIIC0DCCAjmgAwIBAgIBADANBgkqhkiG9w0BAQUFADBVMQswCQYDVQQGEwJHQjEk
+MCIGA1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENBMQ4wDAYDVQQIEwVX
+YWxlczEQMA4GA1UEBxMHRXJ3IFdlbjAeFw0xMjA2MDEwMDAwMDBaFw0yMjA2MDEw
+MDAwMDBaMFUxCzAJBgNVBAYTAkdCMSQwIgYDVQQKExtDZXJ0aWZpY2F0ZSBUcmFu
+c3BhcmVuY3kgQ0ExDjAMBgNVBAgTBVdhbGVzMRAwDgYDVQQHEwdFcncgV2VuMIGf
+MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDVimhTYhCicRmTbneDIRgcKkATxtB7
+jHbrkVfT0PtLO1FuzsvRyY2RxS90P6tjXVUJnNE6uvMa5UFEJFGnTHgW8iQ8+EjP
+KDHM5nugSlojgZ88ujfmJNnDvbKZuDnd/iYx0ss6hPx7srXFL8/BT/9Ab1zURmnL
+svfP34b7arnRsQIDAQABo4GvMIGsMB0GA1UdDgQWBBRfnYgNyHPmVNT4DdjmsMEk
+tEfDVTB9BgNVHSMEdjB0gBRfnYgNyHPmVNT4DdjmsMEktEfDVaFZpFcwVTELMAkG
+A1UEBhMCR0IxJDAiBgNVBAoTG0NlcnRpZmljYXRlIFRyYW5zcGFyZW5jeSBDQTEO
+MAwGA1UECBMFV2FsZXMxEDAOBgNVBAcTB0VydyBXZW6CAQAwDAYDVR0TBAUwAwEB
+/zANBgkqhkiG9w0BAQUFAAOBgQAGCMxKbWTyIF4UbASydvkrDvqUpdryOvw4BmBt
+OZDQoeojPUApV2lGOwRmYef6HReZFSCa6i4Kd1F2QRIn18ADB8dHDmFYT9czQiRy
+f1HWkLxHqd81TbD26yWVXeGJPE3VICskovPkQNJ0tU4b03YmnKliibduyqQQkOFP
+OwqULg==
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIC0DCCAjmgAwIBAgIBADANBgkqhkiG9w0BAQUFADBVMQswCQYDVQQGEwJHQjEk
+MCIGA1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENBMQ4wDAYDVQQIEwVX
+YWxlczEQMA4GA1UEBxMHRXJ3IFdlbjAeFw0xMjA2MDEwMDAwMDBaFw0yMjA2MDEw
+MDAwMDBaMFUxCzAJBgNVBAYTAkdCMSQwIgYDVQQKExtDZXJ0aWZpY2F0ZSBUcmFu
+c3BhcmVuY3kgQ0ExDjAMBgNVBAgTBVdhbGVzMRAwDgYDVQQHEwdFcncgV2VuMIGf
+MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDVimhTYhCicRmTbneDIRgcKkATxtB7
+jHbrkVfT0PtLO1FuzsvRyY2RxS90P6tjXVUJnNE6uvMa5UFEJFGnTHgW8iQ8+EjP
+KDHM5nugSlojgZ88ujfmJNnDvbKZuDnd/iYx0ss6hPx7srXFL8/BT/9Ab1zURmnL
+svfP34b7arnRsQIDAQABo4GvMIGsMB0GA1UdDgQWBBRfnYgNyHPmVNT4DdjmsMEk
+tEfDVTB9BgNVHSMEdjB0gBRfnYgNyHPmVNT4DdjmsMEktEfDVaFZpFcwVTELMAkG
+A1UEBhMCR0IxJDAiBgNVBAoTG0NlcnRpZmljYXRlIFRyYW5zcGFyZW5jeSBDQTEO
+MAwGA1UECBMFV2FsZXMxEDAOBgNVBAcTB0VydyBXZW6CAQAwDAYDVR0TBAUwAwEB
+/zANBgkqhkiG9w0BAQUFAAOBgQAGCMxKbWTyIF4UbASydvkrDvqUpdryOvw4BmBt
+OZDQoeojPUApV2lGOwRmYef6HReZFSCa6i4Kd1F2QRIn18ADB8dHDmFYT9czQiRy
+f1HWkLxHqd81TbD26yWVXeGJPE3VICskovPkQNJ0tU4b03YmnKliibduyqQQkOFP
+OwqULg==
+-----END CERTIFICATE-----`
+
+// pemCACertBad is a PEM block containinng invalid data that should not decode.
+const pemCACertBad = `
+-----BEGIN CERTIFICATE-----
+MIIC0DCCAjmgAwIBAgIBADANBgkqhkiG9w0BAQUFADBVMQswCQYDVQQGEwJHQjEk
+MCIGA1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENBMQ4wDAYDVQQIEwVX
+YWxlczEQMA4GA1UEBxMHRXJ3IFdlbjAeFw0xMjA2MDEwMDAwMDBaFw0yMjA2MDEw
+MDAwMDBaMFUxCzAJBgNVBAYTAkdCMSQwIgYDVQQKExtDZXJ0aWZpY2F0ZSBUcmFu
+c3BhcmVuY3kgQ0ExDjAMBgNVBAgTBVdhbGVzMRAwDgYDVQQHEwdFcncgV2VuMIGf
+MA0GCSqGSIb3DQEBA!"£$%^&&**SDFSKJ$%%^%^%^%&^&^!"£$%%IRgcKkATxtB7
+jHbrkVfT0PtLO1FuzsvRyY2RxS90P6tjXVUJnNE6uvMa5UFEJFGnTHgW8iQ8+EjP
+KDHM5nugSlojgZ88ujfmJNnDvbKZuDnd/iYx0ss6hPx7srXFL8/BT/9Ab1zURmnL
+svfP34b7arnRsQIDAQABo4GvMIGsMB0GA1UdDgQWBBRfnYgNyHPmVNT4DdjmsMEk
+tEfDVTB9BgNVHSMEdjB0gBRfnYgNyHPmVNT4DdjmsMEktEfDVaFZpFcwVTELMAkG
+A1UEBhMCR0IxJDAiBgNVBAoTG0NlcnRpZmljYXRlIFRyYW5zcGFyZW5jeSBDQTEO
+MAwGA1UECBMFV2FsZXMxEDAOBgNVBAcTB0VydyBXZW6CAQAwDAYDVR0TBAUwAwEB
+/zANBgkqhkiG9w0BAQUFAAOBgQAGCMxKbWTyIF4UbASydvkrDvqUpdryOvw4BmBt
+OZDQoeojPUApV2lGOwRmYef6HReZFSCa6i4Kd1F2QRIn18ADB8dHDmFYT9czQiRy
+f1HWkLxHqd81TbD26yWVXeGJPE3VICskovPkQNJ0tU4b03YmnKliibduyqQQkOFP
+OwqULg==
+-----END CERTIFICATE-----`
+
+// pemCACertMultiple is a PEM block containing a valid CA and intermediate
+// certificate, specifically pemCACert above and then:
+//
+//	Data:
+//	    Version: 3 (0x2)
+//	    Serial Number: 9 (0x9)
+//	Signature Algorithm: sha1WithRSAEncryption
+//	    Issuer: C=GB, O=Certificate Transparency CA, ST=Wales, L=Erw Wen
+//	    Validity
+//	        Not Before: Jun  1 00:00:00 2012 GMT
+//	        Not After : Jun  1 00:00:00 2022 GMT
+//	    Subject: C=GB, O=Certificate Transparency Intermediate CA, ST=Wales, L=Erw Wen
+//	    Subject Public Key Info:
+//	        Public Key Algorithm: rsaEncryption
+//	            Public-Key: (1024 bit)
+//	            Modulus:
+//	                00:d7:6a:67:8d:11:6f:52:2e:55:ff:82:1c:90:64:
+//	                25:08:b7:07:4b:14:d7:71:15:90:64:f7:92:7e:fd:
+//	                ed:b8:71:35:a1:36:5e:e7:de:18:cb:d5:ce:86:5f:
+//	                86:0c:78:f4:33:b4:d0:d3:d3:40:77:02:e7:a3:ef:
+//	                54:2b:1d:fe:9b:ba:a7:cd:f9:4d:c5:97:5f:c7:29:
+//	                f8:6f:10:5f:38:1b:24:35:35:cf:9c:80:0f:5c:a7:
+//	                80:c1:d3:c8:44:00:ee:65:d1:6e:e9:cf:52:db:8a:
+//	                df:fe:50:f5:c4:93:35:0b:21:90:bf:50:d5:bc:36:
+//	                f3:ca:c5:a8:da:ae:92:cd:8b
+//	            Exponent: 65537 (0x10001)
+//	    X509v3 extensions:
+//	        X509v3 Subject Key Identifier:
+//	            96:55:08:05:02:78:47:9E:87:73:76:41:31:BC:14:3A:47:E2:29:AB
+//	        X509v3 Authority Key Identifier:
+//	            keyid:5F:9D:88:0D:C8:73:E6:54:D4:F8:0D:D8:E6:B0:C1:24:B4:47:C3:55
+//	            DirName:/C=GB/O=Certificate Transparency CA/ST=Wales/L=Erw Wen
+//	            serial:00
+//
+//	        X509v3 Basic Constraints:
+//	            CA:TRUE
+//	Signature Algorithm: sha1WithRSAEncryption
+//	     22:06:da:b1:c6:6b:71:dc:e0:95:c3:f6:aa:2e:f7:2c:f7:76:
+//	     1b:e7:ab:d7:fc:39:c3:1a:4c:fe:1b:d9:6d:67:34:ca:82:f2:
+//	     2d:de:5a:0c:8b:bb:dd:82:5d:7b:6f:3e:76:12:ad:8d:b3:00:
+//	     a7:e2:11:69:88:60:23:26:22:84:c3:aa:5d:21:91:ef:da:10:
+//	     bf:92:35:d3:7b:3a:2a:34:0d:59:41:9b:94:a4:85:66:f3:fa:
+//	     c3:cd:8b:53:d5:a4:e9:82:70:ea:d2:97:b0:72:10:f9:ce:4a:
+//	     21:38:b1:88:11:14:3b:93:fa:4e:7a:87:dd:37:e1:38:5f:2c:
+//	     29:08
+const pemCACertMultiple = `
+-----BEGIN CERTIFICATE-----
+MIIC0DCCAjmgAwIBAgIBADANBgkqhkiG9w0BAQUFADBVMQswCQYDVQQGEwJHQjEk
+MCIGA1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENBMQ4wDAYDVQQIEwVX
+YWxlczEQMA4GA1UEBxMHRXJ3IFdlbjAeFw0xMjA2MDEwMDAwMDBaFw0yMjA2MDEw
+MDAwMDBaMFUxCzAJBgNVBAYTAkdCMSQwIgYDVQQKExtDZXJ0aWZpY2F0ZSBUcmFu
+c3BhcmVuY3kgQ0ExDjAMBgNVBAgTBVdhbGVzMRAwDgYDVQQHEwdFcncgV2VuMIGf
+MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDVimhTYhCicRmTbneDIRgcKkATxtB7
+jHbrkVfT0PtLO1FuzsvRyY2RxS90P6tjXVUJnNE6uvMa5UFEJFGnTHgW8iQ8+EjP
+KDHM5nugSlojgZ88ujfmJNnDvbKZuDnd/iYx0ss6hPx7srXFL8/BT/9Ab1zURmnL
+svfP34b7arnRsQIDAQABo4GvMIGsMB0GA1UdDgQWBBRfnYgNyHPmVNT4DdjmsMEk
+tEfDVTB9BgNVHSMEdjB0gBRfnYgNyHPmVNT4DdjmsMEktEfDVaFZpFcwVTELMAkG
+A1UEBhMCR0IxJDAiBgNVBAoTG0NlcnRpZmljYXRlIFRyYW5zcGFyZW5jeSBDQTEO
+MAwGA1UECBMFV2FsZXMxEDAOBgNVBAcTB0VydyBXZW6CAQAwDAYDVR0TBAUwAwEB
+/zANBgkqhkiG9w0BAQUFAAOBgQAGCMxKbWTyIF4UbASydvkrDvqUpdryOvw4BmBt
+OZDQoeojPUApV2lGOwRmYef6HReZFSCa6i4Kd1F2QRIn18ADB8dHDmFYT9czQiRy
+f1HWkLxHqd81TbD26yWVXeGJPE3VICskovPkQNJ0tU4b03YmnKliibduyqQQkOFP
+OwqULg==
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIC3TCCAkagAwIBAgIBCTANBgkqhkiG9w0BAQUFADBVMQswCQYDVQQGEwJHQjEk
+MCIGA1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENBMQ4wDAYDVQQIEwVX
+YWxlczEQMA4GA1UEBxMHRXJ3IFdlbjAeFw0xMjA2MDEwMDAwMDBaFw0yMjA2MDEw
+MDAwMDBaMGIxCzAJBgNVBAYTAkdCMTEwLwYDVQQKEyhDZXJ0aWZpY2F0ZSBUcmFu
+c3BhcmVuY3kgSW50ZXJtZWRpYXRlIENBMQ4wDAYDVQQIEwVXYWxlczEQMA4GA1UE
+BxMHRXJ3IFdlbjCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA12pnjRFvUi5V
+/4IckGQlCLcHSxTXcRWQZPeSfv3tuHE1oTZe594Yy9XOhl+GDHj0M7TQ09NAdwLn
+o+9UKx3+m7qnzflNxZdfxyn4bxBfOBskNTXPnIAPXKeAwdPIRADuZdFu6c9S24rf
+/lD1xJM1CyGQv1DVvDbzysWo2q6SzYsCAwEAAaOBrzCBrDAdBgNVHQ4EFgQUllUI
+BQJ4R56Hc3ZBMbwUOkfiKaswfQYDVR0jBHYwdIAUX52IDchz5lTU+A3Y5rDBJLRH
+w1WhWaRXMFUxCzAJBgNVBAYTAkdCMSQwIgYDVQQKExtDZXJ0aWZpY2F0ZSBUcmFu
+c3BhcmVuY3kgQ0ExDjAMBgNVBAgTBVdhbGVzMRAwDgYDVQQHEwdFcncgV2VuggEA
+MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEAIgbascZrcdzglcP2qi73
+LPd2G+er1/w5wxpM/hvZbWc0yoLyLd5aDIu73YJde28+dhKtjbMAp+IRaYhgIyYi
+hMOqXSGR79oQv5I103s6KjQNWUGblKSFZvP6w82LU9Wk6YJw6tKXsHIQ+c5KITix
+iBEUO5P6TnqH3TfhOF8sKQg=
+-----END CERTIFICATE-----`
+
+// pemFakeCACert is a test CA cert for testing.
+//
+//	Data:
+//	    Version: 3 (0x2)
+//	    Serial Number:
+//	        b6:31:d2:ac:21:ab:65:20
+//	Signature Algorithm: sha256WithRSAEncryption
+//	    Issuer: C=GB, ST=London, L=London, O=Google, OU=Eng, CN=FakeCertificateAuthority
+//	    Validity
+//	        Not Before: Jul 11 12:23:26 2016 GMT
+//	        Not After : Jul 11 12:23:26 2017 GMT
+//	    Subject: C=GB, ST=London, L=London, O=Google, OU=Eng, CN=FakeCertificateAuthority
+//	    Subject Public Key Info:
+//	        Public Key Algorithm: rsaEncryption
+//	            Public-Key: (2048 bit)
+//	            Modulus:
+//	                00:a5:41:9a:7a:2d:98:a3:b5:78:6f:15:21:db:0c:
+//	                c1:0e:a1:f8:26:f5:b3:b2:67:85:dc:a1:e6:b7:83:
+//	                6d:da:63:da:d0:f6:a3:ff:bc:43:f5:2b:9f:00:19:
+//	                6e:6b:60:4b:43:20:6e:e2:cb:2e:b6:65:ed:9b:dc:
+//	                80:c3:e1:5a:96:af:60:78:0e:0e:fb:8f:ea:3e:3d:
+//	                c9:67:8f:a4:57:1c:ba:e4:f3:37:a9:2f:dd:11:9d:
+//	                10:5d:e5:d6:ef:d4:3b:06:d9:34:43:42:bb:bb:be:
+//	                43:40:2b:e3:b6:d1:b5:6c:58:12:34:96:14:d4:fc:
+//	                49:79:c5:26:8c:24:7d:b3:12:f5:f6:3e:b7:41:46:
+//	                6b:6d:3a:41:fd:7c:e3:b5:fc:96:6c:c6:cc:ad:8d:
+//	                48:09:73:44:64:ea:4f:17:1d:0a:4b:14:5a:19:07:
+//	                4a:32:0f:41:2e:e4:85:bd:a1:e1:9b:de:63:7c:3b:
+//	                bc:ec:aa:93:2a:0b:a8:c7:24:34:54:42:38:a5:d1:
+//	                0c:c4:f9:9e:7c:69:42:71:77:d7:95:aa:bb:13:3d:
+//	                f3:cc:c7:5d:b3:fd:76:25:25:e3:da:14:0e:59:81:
+//	                e8:2c:58:e8:09:29:7d:22:02:91:95:81:eb:55:6f:
+//	                2f:17:b9:af:4a:f3:84:8b:24:6e:ea:14:6b:bb:90:
+//	                84:35
+//	            Exponent: 65537 (0x10001)
+//	    X509v3 extensions:
+//	        X509v3 Subject Key Identifier:
+//	            01:02:03:04
+//	        X509v3 Authority Key Identifier:
+//	            keyid:01:02:03:04
+//
+//	        X509v3 Basic Constraints: critical
+//	            CA:TRUE, pathlen:10
+//	        X509v3 Key Usage: critical
+//	            Digital Signature, Non Repudiation, Key Encipherment, Data Encipherment, Key Agreement, Certificate Sign, CRL Sign, Encipher Only, Decipher Only
+//	Signature Algorithm: sha256WithRSAEncryption
+//	     92:be:33:eb:d5:d4:32:e7:9e:4e:65:2a:e8:3f:67:b8:f4:d7:
+//	     34:ab:95:11:6a:5d:ba:fd:57:9b:94:6e:8d:20:be:fb:7a:e1:
+//	     49:ca:39:ea:92:d3:81:5a:b1:87:a3:9f:50:a4:e0:1e:11:de:
+//	     c4:d1:07:a1:ca:d1:97:1a:92:bd:73:9a:11:ec:6a:9a:52:11:
+//	     2d:40:e1:3b:4f:3c:1f:81:3f:4c:ab:6a:02:84:4f:8b:18:36:
+//	     7a:cc:5c:a9:0e:25:2b:cd:57:53:88:d9:eb:82:b1:ce:62:76:
+//	     56:d4:23:9e:01:b3:6d:2b:49:ea:d4:3a:c2:f5:76:a7:b3:2d:
+//	     24:97:6f:b4:1c:74:6b:95:85:f6:b5:41:56:82:3c:ed:be:96:
+//	     1e:5e:6a:2d:7b:f7:fd:7d:6e:3f:fb:c2:ec:61:b3:7c:7f:3b:
+//	     f5:9c:64:61:5f:02:93:87:cd:81:f9:7e:53:3e:c1:f5:79:85:
+//	     f4:41:87:c7:ca:bd:af:ab:2b:a4:aa:a8:1d:2c:50:ad:23:8f:
+//	     db:13:1d:71:8a:85:bd:ac:59:6c:c4:53:c5:71:0c:90:91:f3:
+//	     0b:41:ef:da:6e:27:bb:09:57:9c:97:b9:d7:fc:20:96:c5:75:
+//	     96:ce:2e:6c:a8:b6:6e:b0:4d:0f:3e:01:95:ea:8b:cd:ae:47:
+//	     d0:d9:01:b7
+const pemFakeCACert = `
+-----BEGIN CERTIFICATE-----
+MIIDrDCCApSgAwIBAgIJALYx0qwhq2UgMA0GCSqGSIb3DQEBCwUAMHExCzAJBgNV
+BAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xDzANBgNVBAcMBkxvbmRvbjEPMA0GA1UE
+CgwGR29vZ2xlMQwwCgYDVQQLDANFbmcxITAfBgNVBAMMGEZha2VDZXJ0aWZpY2F0
+ZUF1dGhvcml0eTAeFw0xNjA3MTExMjIzMjZaFw0xNzA3MTExMjIzMjZaMHExCzAJ
+BgNVBAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xDzANBgNVBAcMBkxvbmRvbjEPMA0G
+A1UECgwGR29vZ2xlMQwwCgYDVQQLDANFbmcxITAfBgNVBAMMGEZha2VDZXJ0aWZp
+Y2F0ZUF1dGhvcml0eTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKVB
+mnotmKO1eG8VIdsMwQ6h+Cb1s7Jnhdyh5reDbdpj2tD2o/+8Q/UrnwAZbmtgS0Mg
+buLLLrZl7ZvcgMPhWpavYHgODvuP6j49yWePpFccuuTzN6kv3RGdEF3l1u/UOwbZ
+NENCu7u+Q0Ar47bRtWxYEjSWFNT8SXnFJowkfbMS9fY+t0FGa206Qf1847X8lmzG
+zK2NSAlzRGTqTxcdCksUWhkHSjIPQS7khb2h4ZveY3w7vOyqkyoLqMckNFRCOKXR
+DMT5nnxpQnF315WquxM988zHXbP9diUl49oUDlmB6CxY6AkpfSICkZWB61VvLxe5
+r0rzhIskbuoUa7uQhDUCAwEAAaNHMEUwDQYDVR0OBAYEBAECAwQwDwYDVR0jBAgw
+BoAEAQIDBDASBgNVHRMBAf8ECDAGAQH/AgEKMA8GA1UdDwEB/wQFAwMH/4AwDQYJ
+KoZIhvcNAQELBQADggEBAJK+M+vV1DLnnk5lKug/Z7j01zSrlRFqXbr9V5uUbo0g
+vvt64UnKOeqS04FasYejn1Ck4B4R3sTRB6HK0Zcakr1zmhHsappSES1A4TtPPB+B
+P0yragKET4sYNnrMXKkOJSvNV1OI2euCsc5idlbUI54Bs20rSerUOsL1dqezLSSX
+b7QcdGuVhfa1QVaCPO2+lh5eai179/19bj/7wuxhs3x/O/WcZGFfApOHzYH5flM+
+wfV5hfRBh8fKva+rK6SqqB0sUK0jj9sTHXGKhb2sWWzEU8VxDJCR8wtB79puJ7sJ
+V5yXudf8IJbFdZbOLmyotm6wTQ8+AZXqi82uR9DZAbc=
+-----END CERTIFICATE-----`

--- a/internal/x509util/files.go
+++ b/internal/x509util/files.go
@@ -1,0 +1,53 @@
+// Copyright 2016 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package x509util
+
+import (
+	"encoding/pem"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// TODO(phboneff): inline / delete this
+// ReadPossiblePEMFile loads data from a file which may be in DER format
+// or may be in PEM format (with the given blockname).
+func ReadPossiblePEMFile(filename, blockname string) ([][]byte, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to read data: %v", filename, err)
+	}
+	return dePEM(data, blockname), nil
+}
+
+func dePEM(data []byte, blockname string) [][]byte {
+	var results [][]byte
+	if strings.Contains(string(data), "BEGIN "+blockname) {
+		rest := data
+		for {
+			var block *pem.Block
+			block, rest = pem.Decode(rest)
+			if block == nil {
+				break
+			}
+			if block.Type == blockname {
+				results = append(results, block.Bytes)
+			}
+		}
+	} else {
+		results = append(results, data)
+	}
+	return results
+}

--- a/internal/x509util/pem_cert_pool.go
+++ b/internal/x509util/pem_cert_pool.go
@@ -57,6 +57,13 @@ func (p *PEMCertPool) AddCert(cert *x509.Certificate) {
 	}
 }
 
+// Included indicates whether the given cert is included in the pool.
+func (p *PEMCertPool) Included(cert *x509.Certificate) bool {
+	fingerprint := sha256.Sum256(cert.Raw)
+	_, ok := p.fingerprintToCertMap[fingerprint]
+	return ok
+}
+
 // AppendCertsFromPEM adds certs to the pool from a byte slice assumed to contain PEM encoded data.
 // Skips over non certificate blocks in the data. Returns true if all certificates in the
 // data were parsed and added to the pool successfully and at least one certificate was found.

--- a/internal/x509util/pem_cert_pool.go
+++ b/internal/x509util/pem_cert_pool.go
@@ -1,0 +1,113 @@
+// Copyright 2016 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package x509util
+
+import (
+	"crypto/sha256"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/google/certificate-transparency-go/x509"
+	"k8s.io/klog/v2"
+)
+
+// String for certificate blocks in BEGIN / END PEM headers
+const pemCertificateBlockType string = "CERTIFICATE"
+
+// PEMCertPool is a wrapper / extension to x509.CertPool. It allows us to access the
+// raw certs, which we need to serve get-roots request and has stricter handling on loading
+// certs into the pool. CertPool ignores errors if at least one cert loads correctly but
+// PEMCertPool requires all certs to load.
+type PEMCertPool struct {
+	// maps from sha-256 to certificate, used for dup detection
+	fingerprintToCertMap map[[sha256.Size]byte]x509.Certificate
+	rawCerts             []*x509.Certificate
+	certPool             *x509.CertPool
+}
+
+// NewPEMCertPool creates a new, empty, instance of PEMCertPool.
+func NewPEMCertPool() *PEMCertPool {
+	return &PEMCertPool{fingerprintToCertMap: make(map[[sha256.Size]byte]x509.Certificate), certPool: x509.NewCertPool()}
+}
+
+// AddCert adds a certificate to a pool. Uses fingerprint to weed out duplicates.
+// cert must not be nil.
+func (p *PEMCertPool) AddCert(cert *x509.Certificate) {
+	fingerprint := sha256.Sum256(cert.Raw)
+	_, ok := p.fingerprintToCertMap[fingerprint]
+
+	if !ok {
+		p.fingerprintToCertMap[fingerprint] = *cert
+		p.certPool.AddCert(cert)
+		p.rawCerts = append(p.rawCerts, cert)
+	}
+}
+
+// AppendCertsFromPEM adds certs to the pool from a byte slice assumed to contain PEM encoded data.
+// Skips over non certificate blocks in the data. Returns true if all certificates in the
+// data were parsed and added to the pool successfully and at least one certificate was found.
+func (p *PEMCertPool) AppendCertsFromPEM(pemCerts []byte) (ok bool) {
+	for len(pemCerts) > 0 {
+		var block *pem.Block
+		block, pemCerts = pem.Decode(pemCerts)
+		if block == nil {
+			break
+		}
+		if block.Type != pemCertificateBlockType || len(block.Headers) != 0 {
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if x509.IsFatal(err) {
+			klog.Warningf("error parsing PEM certificate: %v", err)
+			return false
+		}
+
+		p.AddCert(cert)
+		ok = true
+	}
+
+	return
+}
+
+// AppendCertsFromPEMFile adds certs from a file that contains concatenated PEM data.
+func (p *PEMCertPool) AppendCertsFromPEMFile(pemFile string) error {
+	pemData, err := os.ReadFile(pemFile)
+	if err != nil {
+		return fmt.Errorf("failed to load PEM certs file: %v", err)
+	}
+
+	if !p.AppendCertsFromPEM(pemData) {
+		return errors.New("failed to parse PEM certs file")
+	}
+	return nil
+}
+
+// Subjects returns a list of the DER-encoded subjects of all of the certificates in the pool.
+func (p *PEMCertPool) Subjects() (res [][]byte) {
+	return p.certPool.Subjects()
+}
+
+// CertPool returns the underlying CertPool.
+func (p *PEMCertPool) CertPool() *x509.CertPool {
+	return p.certPool
+}
+
+// RawCertificates returns a list of the raw bytes of certificates that are in this pool
+func (p *PEMCertPool) RawCertificates() []*x509.Certificate {
+	return p.rawCerts
+}

--- a/internal/x509util/pem_cert_pool_test.go
+++ b/internal/x509util/pem_cert_pool_test.go
@@ -1,0 +1,109 @@
+// Copyright 2016 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package x509util_test
+
+import (
+	"encoding/pem"
+	"testing"
+
+	"github.com/google/certificate-transparency-go/x509"
+	"github.com/google/certificate-transparency-go/x509util"
+)
+
+func TestLoadSingleCertFromPEMs(t *testing.T) {
+	for _, p := range []string{pemCACert, pemCACertWithOtherStuff, pemCACertDuplicated} {
+		pool := x509util.NewPEMCertPool()
+
+		ok := pool.AppendCertsFromPEM([]byte(p))
+		if !ok {
+			t.Fatal("Expected to append a certificate ok")
+		}
+		if got, want := len(pool.Subjects()), 1; got != want {
+			t.Fatalf("Got %d cert(s) in the pool, expected %d", got, want)
+		}
+	}
+}
+
+func TestBadOrEmptyCertificateRejected(t *testing.T) {
+	for _, p := range []string{pemUnknownBlockType, pemCACertBad} {
+		pool := x509util.NewPEMCertPool()
+
+		ok := pool.AppendCertsFromPEM([]byte(p))
+		if ok {
+			t.Fatal("Expected appending no certs")
+		}
+		if got, want := len(pool.Subjects()), 0; got != want {
+			t.Fatalf("Got %d cert(s) in pool, expected %d", got, want)
+		}
+	}
+}
+
+func TestLoadMultipleCertsFromPEM(t *testing.T) {
+	pool := x509util.NewPEMCertPool()
+
+	ok := pool.AppendCertsFromPEM([]byte(pemCACertMultiple))
+	if !ok {
+		t.Fatal("Rejected valid multiple certs")
+	}
+	if got, want := len(pool.Subjects()), 2; got != want {
+		t.Fatalf("Got %d certs in pool, expected %d", got, want)
+	}
+}
+
+func TestIncluded(t *testing.T) {
+	certs := [2]*x509.Certificate{parsePEM(t, pemCACert), parsePEM(t, pemFakeCACert)}
+
+	// Note: tests are cumulative
+	tests := []struct {
+		cert *x509.Certificate
+		want [2]bool
+	}{
+		{cert: nil, want: [2]bool{false, false}},
+		{cert: nil, want: [2]bool{false, false}},
+		{cert: certs[0], want: [2]bool{true, false}},
+		{cert: nil, want: [2]bool{true, false}},
+		{cert: certs[0], want: [2]bool{true, false}},
+		{cert: certs[1], want: [2]bool{true, true}},
+		{cert: nil, want: [2]bool{true, true}},
+		{cert: certs[1], want: [2]bool{true, true}},
+	}
+
+	pool := x509util.NewPEMCertPool()
+	for _, test := range tests {
+		if test.cert != nil {
+			pool.AddCert(test.cert)
+		}
+		for i, cert := range certs {
+			got := pool.Included(cert)
+			if got != test.want[i] {
+				t.Errorf("pool.Included(cert[%d])=%v, want %v", i, got, test.want[i])
+			}
+		}
+	}
+}
+
+func parsePEM(t *testing.T, pemCert string) *x509.Certificate {
+	var block *pem.Block
+	block, _ = pem.Decode([]byte(pemCert))
+	if block == nil || block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+		t.Fatal("No PEM data found")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if x509.IsFatal(err) {
+		t.Fatalf("Failed to parse PEM certificate: %v", err)
+	}
+	return cert
+}

--- a/internal/x509util/pem_cert_pool_test.go
+++ b/internal/x509util/pem_cert_pool_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/certificate-transparency-go/x509"
-	"github.com/google/certificate-transparency-go/x509util"
+	"github.com/transparency-dev/static-ct/internal/x509util"
 )
 
 func TestLoadSingleCertFromPEMs(t *testing.T) {

--- a/internal/x509util/x509util.go
+++ b/internal/x509util/x509util.go
@@ -1,0 +1,900 @@
+// Copyright 2016 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package x509util includes utility code for working with X.509
+// certificates from the x509 package.
+package x509util
+
+import (
+	"bytes"
+	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+
+	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go/asn1"
+	"github.com/google/certificate-transparency-go/gossip/minimal/x509ext"
+	"github.com/google/certificate-transparency-go/tls"
+	"github.com/google/certificate-transparency-go/x509"
+	"github.com/google/certificate-transparency-go/x509/pkix"
+)
+
+// OIDForStandardExtension indicates whether oid identifies a standard extension.
+// Standard extensions are listed in RFC 5280 (and other RFCs).
+func OIDForStandardExtension(oid asn1.ObjectIdentifier) bool {
+	if oid.Equal(x509.OIDExtensionSubjectKeyId) ||
+		oid.Equal(x509.OIDExtensionKeyUsage) ||
+		oid.Equal(x509.OIDExtensionExtendedKeyUsage) ||
+		oid.Equal(x509.OIDExtensionAuthorityKeyId) ||
+		oid.Equal(x509.OIDExtensionBasicConstraints) ||
+		oid.Equal(x509.OIDExtensionSubjectAltName) ||
+		oid.Equal(x509.OIDExtensionCertificatePolicies) ||
+		oid.Equal(x509.OIDExtensionNameConstraints) ||
+		oid.Equal(x509.OIDExtensionCRLDistributionPoints) ||
+		oid.Equal(x509.OIDExtensionIssuerAltName) ||
+		oid.Equal(x509.OIDExtensionSubjectDirectoryAttributes) ||
+		oid.Equal(x509.OIDExtensionInhibitAnyPolicy) ||
+		oid.Equal(x509.OIDExtensionPolicyConstraints) ||
+		oid.Equal(x509.OIDExtensionPolicyMappings) ||
+		oid.Equal(x509.OIDExtensionFreshestCRL) ||
+		oid.Equal(x509.OIDExtensionSubjectInfoAccess) ||
+		oid.Equal(x509.OIDExtensionAuthorityInfoAccess) ||
+		oid.Equal(x509.OIDExtensionIPPrefixList) ||
+		oid.Equal(x509.OIDExtensionASList) ||
+		oid.Equal(x509.OIDExtensionCTPoison) ||
+		oid.Equal(x509.OIDExtensionCTSCT) {
+		return true
+	}
+	return false
+}
+
+// OIDInExtensions checks whether the extension identified by oid is present in extensions
+// and returns how many times it occurs together with an indication of whether any of them
+// are marked critical.
+func OIDInExtensions(oid asn1.ObjectIdentifier, extensions []pkix.Extension) (int, bool) {
+	count := 0
+	critical := false
+	for _, ext := range extensions {
+		if ext.Id.Equal(oid) {
+			count++
+			if ext.Critical {
+				critical = true
+			}
+		}
+	}
+	return count, critical
+}
+
+// String formatting for various X.509/ASN.1 types
+func bitStringToString(b asn1.BitString) string { // nolint:deadcode,unused
+	result := hex.EncodeToString(b.Bytes)
+	bitsLeft := b.BitLength % 8
+	if bitsLeft != 0 {
+		result += " (" + strconv.Itoa(8-bitsLeft) + " unused bits)"
+	}
+	return result
+}
+
+func publicKeyAlgorithmToString(algo x509.PublicKeyAlgorithm) string {
+	// Use OpenSSL-compatible strings for the algorithms.
+	switch algo {
+	case x509.RSA:
+		return "rsaEncryption"
+	case x509.DSA:
+		return "dsaEncryption"
+	case x509.ECDSA:
+		return "id-ecPublicKey"
+	default:
+		return strconv.Itoa(int(algo))
+	}
+}
+
+// appendHexData adds a hex dump of binary data to buf, with line breaks
+// after each set of count bytes, and with each new line prefixed with the
+// given prefix.
+func appendHexData(buf *bytes.Buffer, data []byte, count int, prefix string) {
+	for ii, b := range data {
+		if ii%count == 0 {
+			if ii > 0 {
+				buf.WriteString("\n")
+			}
+			buf.WriteString(prefix)
+		}
+		buf.WriteString(fmt.Sprintf("%02x:", b))
+	}
+}
+
+func curveOIDToString(oid asn1.ObjectIdentifier) (t string, bitlen int) {
+	switch {
+	case oid.Equal(x509.OIDNamedCurveP224):
+		return "secp224r1", 224
+	case oid.Equal(x509.OIDNamedCurveP256):
+		return "prime256v1", 256
+	case oid.Equal(x509.OIDNamedCurveP384):
+		return "secp384r1", 384
+	case oid.Equal(x509.OIDNamedCurveP521):
+		return "secp521r1", 521
+	case oid.Equal(x509.OIDNamedCurveP192):
+		return "secp192r1", 192
+	}
+	return fmt.Sprintf("%v", oid), -1
+}
+
+func publicKeyToString(_ x509.PublicKeyAlgorithm, pub interface{}) string {
+	var buf bytes.Buffer
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		bitlen := pub.N.BitLen()
+		buf.WriteString(fmt.Sprintf("                Public Key: (%d bit)\n", bitlen))
+		buf.WriteString("                Modulus:\n")
+		data := pub.N.Bytes()
+		appendHexData(&buf, data, 15, "                    ")
+		buf.WriteString("\n")
+		buf.WriteString(fmt.Sprintf("                Exponent: %d (0x%x)", pub.E, pub.E))
+	case *dsa.PublicKey:
+		buf.WriteString("                pub:\n")
+		appendHexData(&buf, pub.Y.Bytes(), 15, "                    ")
+		buf.WriteString("\n")
+		buf.WriteString("                P:\n")
+		appendHexData(&buf, pub.P.Bytes(), 15, "                    ")
+		buf.WriteString("\n")
+		buf.WriteString("                Q:\n")
+		appendHexData(&buf, pub.Q.Bytes(), 15, "                    ")
+		buf.WriteString("\n")
+		buf.WriteString("                G:\n")
+		appendHexData(&buf, pub.G.Bytes(), 15, "                    ")
+	case *ecdsa.PublicKey:
+		data := elliptic.Marshal(pub.Curve, pub.X, pub.Y)
+		oid, ok := x509.OIDFromNamedCurve(pub.Curve)
+		if !ok {
+			return "                <unsupported elliptic curve>"
+		}
+		oidname, bitlen := curveOIDToString(oid)
+		buf.WriteString(fmt.Sprintf("                Public Key: (%d bit)\n", bitlen))
+		buf.WriteString("                pub:\n")
+		appendHexData(&buf, data, 15, "                    ")
+		buf.WriteString("\n")
+		buf.WriteString(fmt.Sprintf("                ASN1 OID: %s", oidname))
+	default:
+		buf.WriteString(fmt.Sprintf("%v", pub))
+	}
+	return buf.String()
+}
+
+func commaAppend(buf *bytes.Buffer, s string) {
+	if buf.Len() > 0 {
+		buf.WriteString(", ")
+	}
+	buf.WriteString(s)
+}
+
+func keyUsageToString(k x509.KeyUsage) string {
+	var buf bytes.Buffer
+	if k&x509.KeyUsageDigitalSignature != 0 {
+		commaAppend(&buf, "Digital Signature")
+	}
+	if k&x509.KeyUsageContentCommitment != 0 {
+		commaAppend(&buf, "Content Commitment")
+	}
+	if k&x509.KeyUsageKeyEncipherment != 0 {
+		commaAppend(&buf, "Key Encipherment")
+	}
+	if k&x509.KeyUsageDataEncipherment != 0 {
+		commaAppend(&buf, "Data Encipherment")
+	}
+	if k&x509.KeyUsageKeyAgreement != 0 {
+		commaAppend(&buf, "Key Agreement")
+	}
+	if k&x509.KeyUsageCertSign != 0 {
+		commaAppend(&buf, "Certificate Signing")
+	}
+	if k&x509.KeyUsageCRLSign != 0 {
+		commaAppend(&buf, "CRL Signing")
+	}
+	if k&x509.KeyUsageEncipherOnly != 0 {
+		commaAppend(&buf, "Encipher Only")
+	}
+	if k&x509.KeyUsageDecipherOnly != 0 {
+		commaAppend(&buf, "Decipher Only")
+	}
+	return buf.String()
+}
+
+func extKeyUsageToString(u x509.ExtKeyUsage) string {
+	switch u {
+	case x509.ExtKeyUsageAny:
+		return "Any"
+	case x509.ExtKeyUsageServerAuth:
+		return "TLS Web server authentication"
+	case x509.ExtKeyUsageClientAuth:
+		return "TLS Web client authentication"
+	case x509.ExtKeyUsageCodeSigning:
+		return "Signing of executable code"
+	case x509.ExtKeyUsageEmailProtection:
+		return "Email protection"
+	case x509.ExtKeyUsageIPSECEndSystem:
+		return "IPSEC end system"
+	case x509.ExtKeyUsageIPSECTunnel:
+		return "IPSEC tunnel"
+	case x509.ExtKeyUsageIPSECUser:
+		return "IPSEC user"
+	case x509.ExtKeyUsageTimeStamping:
+		return "Time stamping"
+	case x509.ExtKeyUsageOCSPSigning:
+		return "OCSP signing"
+	case x509.ExtKeyUsageMicrosoftServerGatedCrypto:
+		return "Microsoft server gated cryptography"
+	case x509.ExtKeyUsageNetscapeServerGatedCrypto:
+		return "Netscape server gated cryptography"
+	case x509.ExtKeyUsageCertificateTransparency:
+		return "Certificate transparency"
+	default:
+		return "Unknown"
+	}
+}
+
+func attributeOIDToString(oid asn1.ObjectIdentifier) string { // nolint:deadcode,unused
+	switch {
+	case oid.Equal(pkix.OIDCountry):
+		return "Country"
+	case oid.Equal(pkix.OIDOrganization):
+		return "Organization"
+	case oid.Equal(pkix.OIDOrganizationalUnit):
+		return "OrganizationalUnit"
+	case oid.Equal(pkix.OIDCommonName):
+		return "CommonName"
+	case oid.Equal(pkix.OIDSerialNumber):
+		return "SerialNumber"
+	case oid.Equal(pkix.OIDLocality):
+		return "Locality"
+	case oid.Equal(pkix.OIDProvince):
+		return "Province"
+	case oid.Equal(pkix.OIDStreetAddress):
+		return "StreetAddress"
+	case oid.Equal(pkix.OIDPostalCode):
+		return "PostalCode"
+	case oid.Equal(pkix.OIDPseudonym):
+		return "Pseudonym"
+	case oid.Equal(pkix.OIDTitle):
+		return "Title"
+	case oid.Equal(pkix.OIDDnQualifier):
+		return "DnQualifier"
+	case oid.Equal(pkix.OIDName):
+		return "Name"
+	case oid.Equal(pkix.OIDSurname):
+		return "Surname"
+	case oid.Equal(pkix.OIDGivenName):
+		return "GivenName"
+	case oid.Equal(pkix.OIDInitials):
+		return "Initials"
+	case oid.Equal(pkix.OIDGenerationQualifier):
+		return "GenerationQualifier"
+	default:
+		return oid.String()
+	}
+}
+
+// NameToString creates a string description of a pkix.Name object.
+func NameToString(name pkix.Name) string {
+	var result bytes.Buffer
+	addSingle := func(prefix, item string) {
+		if len(item) == 0 {
+			return
+		}
+		commaAppend(&result, prefix)
+		result.WriteString(item)
+	}
+	addList := func(prefix string, items []string) {
+		for _, item := range items {
+			addSingle(prefix, item)
+		}
+	}
+	addList("C=", name.Country)
+	addList("O=", name.Organization)
+	addList("OU=", name.OrganizationalUnit)
+	addList("L=", name.Locality)
+	addList("ST=", name.Province)
+	addList("streetAddress=", name.StreetAddress)
+	addList("postalCode=", name.PostalCode)
+	addSingle("serialNumber=", name.SerialNumber)
+	addSingle("CN=", name.CommonName)
+	for _, atv := range name.Names {
+		value, ok := atv.Value.(string)
+		if !ok {
+			continue
+		}
+		t := atv.Type
+		// All of the defined attribute OIDs are of the form 2.5.4.N, and OIDAttribute is
+		// the 2.5.4 prefix ('id-at' in RFC 5280).
+		if len(t) == 4 && t[0] == pkix.OIDAttribute[0] && t[1] == pkix.OIDAttribute[1] && t[2] == pkix.OIDAttribute[2] {
+			// OID is 'id-at N', so check the final value to figure out which attribute.
+			switch t[3] {
+			case pkix.OIDCommonName[3], pkix.OIDSerialNumber[3], pkix.OIDCountry[3], pkix.OIDLocality[3], pkix.OIDProvince[3],
+				pkix.OIDStreetAddress[3], pkix.OIDOrganization[3], pkix.OIDOrganizationalUnit[3], pkix.OIDPostalCode[3]:
+				continue // covered by explicit fields
+			case pkix.OIDPseudonym[3]:
+				addSingle("pseudonym=", value)
+				continue
+			case pkix.OIDTitle[3]:
+				addSingle("title=", value)
+				continue
+			case pkix.OIDDnQualifier[3]:
+				addSingle("dnQualifier=", value)
+				continue
+			case pkix.OIDName[3]:
+				addSingle("name=", value)
+				continue
+			case pkix.OIDSurname[3]:
+				addSingle("surname=", value)
+				continue
+			case pkix.OIDGivenName[3]:
+				addSingle("givenName=", value)
+				continue
+			case pkix.OIDInitials[3]:
+				addSingle("initials=", value)
+				continue
+			case pkix.OIDGenerationQualifier[3]:
+				addSingle("generationQualifier=", value)
+				continue
+			}
+		}
+		addSingle(t.String()+"=", value)
+	}
+	return result.String()
+}
+
+// OtherNameToString creates a string description of an x509.OtherName object.
+func OtherNameToString(other x509.OtherName) string {
+	return fmt.Sprintf("%v=%v", other.TypeID, hex.EncodeToString(other.Value.Bytes))
+}
+
+// GeneralNamesToString creates a string description of an x509.GeneralNames object.
+func GeneralNamesToString(gname *x509.GeneralNames) string {
+	var buf bytes.Buffer
+	for _, name := range gname.DNSNames {
+		commaAppend(&buf, "DNS:"+name)
+	}
+	for _, email := range gname.EmailAddresses {
+		commaAppend(&buf, "email:"+email)
+	}
+	for _, name := range gname.DirectoryNames {
+		commaAppend(&buf, "DirName:"+NameToString(name))
+	}
+	for _, uri := range gname.URIs {
+		commaAppend(&buf, "URI:"+uri)
+	}
+	for _, ip := range gname.IPNets {
+		if ip.Mask == nil {
+			commaAppend(&buf, "IP Address:"+ip.IP.String())
+		} else {
+			commaAppend(&buf, "IP Address:"+ip.IP.String()+"/"+ip.Mask.String())
+		}
+	}
+	for _, id := range gname.RegisteredIDs {
+		commaAppend(&buf, "Registered ID:"+id.String())
+	}
+	for _, other := range gname.OtherNames {
+		commaAppend(&buf, "othername:"+OtherNameToString(other))
+	}
+	return buf.String()
+}
+
+// CertificateToString generates a string describing the given certificate.
+// The output roughly resembles that from openssl x509 -text.
+func CertificateToString(cert *x509.Certificate) string {
+	var result bytes.Buffer
+	result.WriteString("Certificate:\n")
+	result.WriteString("    Data:\n")
+	result.WriteString(fmt.Sprintf("        Version: %d (%#x)\n", cert.Version, cert.Version-1))
+	result.WriteString(fmt.Sprintf("        Serial Number: %s (0x%s)\n", cert.SerialNumber.Text(10), cert.SerialNumber.Text(16)))
+	result.WriteString(fmt.Sprintf("    Signature Algorithm: %v\n", cert.SignatureAlgorithm))
+	result.WriteString(fmt.Sprintf("        Issuer: %v\n", NameToString(cert.Issuer)))
+	result.WriteString("        Validity:\n")
+	result.WriteString(fmt.Sprintf("            Not Before: %v\n", cert.NotBefore))
+	result.WriteString(fmt.Sprintf("            Not After : %v\n", cert.NotAfter))
+	result.WriteString(fmt.Sprintf("        Subject: %v\n", NameToString(cert.Subject)))
+	result.WriteString("        Subject Public Key Info:\n")
+	result.WriteString(fmt.Sprintf("            Public Key Algorithm: %v\n", publicKeyAlgorithmToString(cert.PublicKeyAlgorithm)))
+	result.WriteString(fmt.Sprintf("%v\n", publicKeyToString(cert.PublicKeyAlgorithm, cert.PublicKey)))
+
+	if len(cert.Extensions) > 0 {
+		result.WriteString("        X509v3 extensions:\n")
+	}
+	// First display the extensions that are already cracked out
+	showAuthKeyID(&result, cert)
+	showSubjectKeyID(&result, cert)
+	showKeyUsage(&result, cert)
+	showExtendedKeyUsage(&result, cert)
+	showBasicConstraints(&result, cert)
+	showSubjectAltName(&result, cert)
+	showNameConstraints(&result, cert)
+	showCertPolicies(&result, cert)
+	showCRLDPs(&result, cert)
+	showAuthInfoAccess(&result, cert)
+	showSubjectInfoAccess(&result, cert)
+	showRPKIAddressRanges(&result, cert)
+	showRPKIASIdentifiers(&result, cert)
+	showCTPoison(&result, cert)
+	showCTSCT(&result, cert)
+	showCTLogSTHInfo(&result, cert)
+
+	showUnhandledExtensions(&result, cert)
+	showSignature(&result, cert)
+
+	return result.String()
+}
+
+func showCritical(result *bytes.Buffer, critical bool) {
+	if critical {
+		result.WriteString(" critical")
+	}
+	result.WriteString("\n")
+}
+
+func showAuthKeyID(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionAuthorityKeyId, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            X509v3 Authority Key Identifier:")
+		showCritical(result, critical)
+		result.WriteString(fmt.Sprintf("                keyid:%v\n", hex.EncodeToString(cert.AuthorityKeyId)))
+	}
+}
+
+func showSubjectKeyID(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionSubjectKeyId, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            X509v3 Subject Key Identifier:")
+		showCritical(result, critical)
+		result.WriteString(fmt.Sprintf("                keyid:%v\n", hex.EncodeToString(cert.SubjectKeyId)))
+	}
+}
+
+func showKeyUsage(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionKeyUsage, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            X509v3 Key Usage:")
+		showCritical(result, critical)
+		result.WriteString(fmt.Sprintf("                %v\n", keyUsageToString(cert.KeyUsage)))
+	}
+}
+
+func showExtendedKeyUsage(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionExtendedKeyUsage, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            X509v3 Extended Key Usage:")
+		showCritical(result, critical)
+		var usages bytes.Buffer
+		for _, usage := range cert.ExtKeyUsage {
+			commaAppend(&usages, extKeyUsageToString(usage))
+		}
+		for _, oid := range cert.UnknownExtKeyUsage {
+			commaAppend(&usages, oid.String())
+		}
+		result.WriteString(fmt.Sprintf("                %v\n", usages.String()))
+	}
+}
+
+func showBasicConstraints(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionBasicConstraints, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            X509v3 Basic Constraints:")
+		showCritical(result, critical)
+		result.WriteString(fmt.Sprintf("                CA:%t", cert.IsCA))
+		if cert.MaxPathLen > 0 || cert.MaxPathLenZero {
+			result.WriteString(fmt.Sprintf(", pathlen:%d", cert.MaxPathLen))
+		}
+		result.WriteString("\n")
+	}
+}
+
+func showSubjectAltName(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionSubjectAltName, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            X509v3 Subject Alternative Name:")
+		showCritical(result, critical)
+		var buf bytes.Buffer
+		for _, name := range cert.DNSNames {
+			commaAppend(&buf, "DNS:"+name)
+		}
+		for _, email := range cert.EmailAddresses {
+			commaAppend(&buf, "email:"+email)
+		}
+		for _, ip := range cert.IPAddresses {
+			commaAppend(&buf, "IP Address:"+ip.String())
+		}
+
+		result.WriteString(fmt.Sprintf("                %v\n", buf.String()))
+		// TODO(drysdale): include other name forms
+	}
+}
+
+func showNameConstraints(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionNameConstraints, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            X509v3 Name Constraints:")
+		showCritical(result, critical)
+		if len(cert.PermittedDNSDomains) > 0 {
+			result.WriteString("                Permitted:\n")
+			var buf bytes.Buffer
+			for _, name := range cert.PermittedDNSDomains {
+				commaAppend(&buf, "DNS:"+name)
+			}
+			result.WriteString(fmt.Sprintf("                  %v\n", buf.String()))
+		}
+		// TODO(drysdale): include other name forms
+	}
+
+}
+
+func showCertPolicies(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionCertificatePolicies, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            X509v3 Certificate Policies:")
+		showCritical(result, critical)
+		for _, oid := range cert.PolicyIdentifiers {
+			result.WriteString(fmt.Sprintf("                Policy: %v\n", oid.String()))
+			// TODO(drysdale): Display any qualifiers associated with the policy
+		}
+	}
+
+}
+
+func showCRLDPs(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionCRLDistributionPoints, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            X509v3 CRL Distribution Points:")
+		showCritical(result, critical)
+		result.WriteString("                Full Name:\n")
+		var buf bytes.Buffer
+		for _, pt := range cert.CRLDistributionPoints {
+			commaAppend(&buf, "URI:"+pt)
+		}
+		result.WriteString(fmt.Sprintf("                    %v\n", buf.String()))
+		// TODO(drysdale): Display other GeneralNames types, plus issuer/reasons/relative-name
+	}
+
+}
+
+func showAuthInfoAccess(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionAuthorityInfoAccess, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            Authority Information Access:")
+		showCritical(result, critical)
+		var issuerBuf bytes.Buffer
+		for _, issuer := range cert.IssuingCertificateURL {
+			commaAppend(&issuerBuf, "URI:"+issuer)
+		}
+		if issuerBuf.Len() > 0 {
+			result.WriteString(fmt.Sprintf("                CA Issuers - %v\n", issuerBuf.String()))
+		}
+		var ocspBuf bytes.Buffer
+		for _, ocsp := range cert.OCSPServer {
+			commaAppend(&ocspBuf, "URI:"+ocsp)
+		}
+		if ocspBuf.Len() > 0 {
+			result.WriteString(fmt.Sprintf("                OCSP - %v\n", ocspBuf.String()))
+		}
+		// TODO(drysdale): Display other GeneralNames types
+	}
+}
+
+func showSubjectInfoAccess(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionSubjectInfoAccess, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            Subject Information Access:")
+		showCritical(result, critical)
+		var tsBuf bytes.Buffer
+		for _, ts := range cert.SubjectTimestamps {
+			commaAppend(&tsBuf, "URI:"+ts)
+		}
+		if tsBuf.Len() > 0 {
+			result.WriteString(fmt.Sprintf("                AD Time Stamping - %v\n", tsBuf.String()))
+		}
+		var repoBuf bytes.Buffer
+		for _, repo := range cert.SubjectCARepositories {
+			commaAppend(&repoBuf, "URI:"+repo)
+		}
+		if repoBuf.Len() > 0 {
+			result.WriteString(fmt.Sprintf("                CA repository - %v\n", repoBuf.String()))
+		}
+	}
+}
+
+func showAddressRange(prefix x509.IPAddressPrefix, afi uint16) string {
+	switch afi {
+	case x509.IPv4AddressFamilyIndicator, x509.IPv6AddressFamilyIndicator:
+		size := 4
+		if afi == x509.IPv6AddressFamilyIndicator {
+			size = 16
+		}
+		ip := make([]byte, size)
+		copy(ip, prefix.Bytes)
+		addr := net.IPNet{IP: ip, Mask: net.CIDRMask(prefix.BitLength, 8*size)}
+		return addr.String()
+	default:
+		return fmt.Sprintf("%x/%d", prefix.Bytes, prefix.BitLength)
+	}
+
+}
+
+func showRPKIAddressRanges(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionIPPrefixList, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            sbgp-ipAddrBlock:")
+		showCritical(result, critical)
+		for _, blocks := range cert.RPKIAddressRanges {
+			afi := blocks.AFI
+			switch afi {
+			case x509.IPv4AddressFamilyIndicator:
+				result.WriteString("                IPv4")
+			case x509.IPv6AddressFamilyIndicator:
+				result.WriteString("                IPv6")
+			default:
+				result.WriteString(fmt.Sprintf("                %d", afi))
+			}
+			if blocks.SAFI != 0 {
+				result.WriteString(fmt.Sprintf(" SAFI=%d", blocks.SAFI))
+			}
+			result.WriteString(":")
+			if blocks.InheritFromIssuer {
+				result.WriteString(" inherit\n")
+				continue
+			}
+			result.WriteString("\n")
+			for _, prefix := range blocks.AddressPrefixes {
+				result.WriteString(fmt.Sprintf("                  %s\n", showAddressRange(prefix, afi)))
+			}
+			for _, ipRange := range blocks.AddressRanges {
+				result.WriteString(fmt.Sprintf("                  [%s, %s]\n", showAddressRange(ipRange.Min, afi), showAddressRange(ipRange.Max, afi)))
+			}
+		}
+	}
+}
+
+func showASIDs(result *bytes.Buffer, asids *x509.ASIdentifiers, label string) {
+	if asids == nil {
+		return
+	}
+	result.WriteString(fmt.Sprintf("                %s:\n", label))
+	if asids.InheritFromIssuer {
+		result.WriteString("                  inherit\n")
+		return
+	}
+	for _, id := range asids.ASIDs {
+		result.WriteString(fmt.Sprintf("                  %d\n", id))
+	}
+	for _, idRange := range asids.ASIDRanges {
+		result.WriteString(fmt.Sprintf("                  %d-%d\n", idRange.Min, idRange.Max))
+	}
+}
+
+func showRPKIASIdentifiers(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionASList, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            sbgp-autonomousSysNum:")
+		showCritical(result, critical)
+		showASIDs(result, cert.RPKIASNumbers, "Autonomous System Numbers")
+		showASIDs(result, cert.RPKIRoutingDomainIDs, "Routing Domain Identifiers")
+	}
+}
+func showCTPoison(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionCTPoison, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            RFC6962 Pre-Certificate Poison:")
+		showCritical(result, critical)
+		result.WriteString("                .....\n")
+	}
+}
+
+func showCTSCT(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509.OIDExtensionCTSCT, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            RFC6962 Certificate Transparency SCT:")
+		showCritical(result, critical)
+		for i, sctData := range cert.SCTList.SCTList {
+			result.WriteString(fmt.Sprintf("              SCT [%d]:\n", i))
+			var sct ct.SignedCertificateTimestamp
+			_, err := tls.Unmarshal(sctData.Val, &sct)
+			if err != nil {
+				appendHexData(result, sctData.Val, 16, "                  ")
+				result.WriteString("\n")
+				continue
+			}
+			result.WriteString(fmt.Sprintf("                  Version: %d\n", sct.SCTVersion))
+			result.WriteString(fmt.Sprintf("                  LogID: %s\n", base64.StdEncoding.EncodeToString(sct.LogID.KeyID[:])))
+			result.WriteString(fmt.Sprintf("                  Timestamp: %d\n", sct.Timestamp))
+			result.WriteString(fmt.Sprintf("                  Signature: %s\n", sct.Signature.Algorithm))
+			result.WriteString("                  Signature:\n")
+			appendHexData(result, sct.Signature.Signature, 16, "                    ")
+			result.WriteString("\n")
+		}
+	}
+}
+
+func showCTLogSTHInfo(result *bytes.Buffer, cert *x509.Certificate) {
+	count, critical := OIDInExtensions(x509ext.OIDExtensionCTSTH, cert.Extensions)
+	if count > 0 {
+		result.WriteString("            Certificate Transparency STH:")
+		showCritical(result, critical)
+		sthInfo, err := x509ext.LogSTHInfoFromCert(cert)
+		if err != nil {
+			result.WriteString("              Failed to decode STH:\n")
+			return
+		}
+		result.WriteString(fmt.Sprintf("              LogURL: %s\n", string(sthInfo.LogURL)))
+		result.WriteString(fmt.Sprintf("              Version: %d\n", sthInfo.Version))
+		result.WriteString(fmt.Sprintf("              TreeSize: %d\n", sthInfo.TreeSize))
+		result.WriteString(fmt.Sprintf("              Timestamp: %d\n", sthInfo.Timestamp))
+		result.WriteString("              RootHash:\n")
+		appendHexData(result, sthInfo.SHA256RootHash[:], 16, "                    ")
+		result.WriteString("\n")
+		result.WriteString(fmt.Sprintf("              TreeHeadSignature: %s\n", sthInfo.TreeHeadSignature.Algorithm))
+		appendHexData(result, sthInfo.TreeHeadSignature.Signature, 16, "                    ")
+		result.WriteString("\n")
+	}
+}
+
+func showUnhandledExtensions(result *bytes.Buffer, cert *x509.Certificate) {
+	for _, ext := range cert.Extensions {
+		// Skip extensions that are already cracked out
+		if oidAlreadyPrinted(ext.Id) {
+			continue
+		}
+		result.WriteString(fmt.Sprintf("            %v:", ext.Id))
+		showCritical(result, ext.Critical)
+		appendHexData(result, ext.Value, 16, "                ")
+		result.WriteString("\n")
+	}
+}
+
+func showSignature(result *bytes.Buffer, cert *x509.Certificate) {
+	result.WriteString(fmt.Sprintf("    Signature Algorithm: %v\n", cert.SignatureAlgorithm))
+	appendHexData(result, cert.Signature, 18, "         ")
+	result.WriteString("\n")
+}
+
+// TODO(drysdale): remove this once all standard OIDs are parsed and printed.
+func oidAlreadyPrinted(oid asn1.ObjectIdentifier) bool {
+	if oid.Equal(x509.OIDExtensionSubjectKeyId) ||
+		oid.Equal(x509.OIDExtensionKeyUsage) ||
+		oid.Equal(x509.OIDExtensionExtendedKeyUsage) ||
+		oid.Equal(x509.OIDExtensionAuthorityKeyId) ||
+		oid.Equal(x509.OIDExtensionBasicConstraints) ||
+		oid.Equal(x509.OIDExtensionSubjectAltName) ||
+		oid.Equal(x509.OIDExtensionCertificatePolicies) ||
+		oid.Equal(x509.OIDExtensionNameConstraints) ||
+		oid.Equal(x509.OIDExtensionCRLDistributionPoints) ||
+		oid.Equal(x509.OIDExtensionAuthorityInfoAccess) ||
+		oid.Equal(x509.OIDExtensionSubjectInfoAccess) ||
+		oid.Equal(x509.OIDExtensionIPPrefixList) ||
+		oid.Equal(x509.OIDExtensionASList) ||
+		oid.Equal(x509.OIDExtensionCTPoison) ||
+		oid.Equal(x509.OIDExtensionCTSCT) ||
+		oid.Equal(x509ext.OIDExtensionCTSTH) {
+		return true
+	}
+	return false
+}
+
+// CertificateFromPEM takes a certificate in PEM format and returns the
+// corresponding x509.Certificate object.
+func CertificateFromPEM(pemBytes []byte) (*x509.Certificate, error) {
+	block, rest := pem.Decode(pemBytes)
+	if len(rest) != 0 {
+		return nil, errors.New("trailing data found after PEM block")
+	}
+	if block == nil {
+		return nil, errors.New("PEM block is nil")
+	}
+	if block.Type != "CERTIFICATE" {
+		return nil, errors.New("PEM block is not a CERTIFICATE")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+// CertificatesFromPEM parses one or more certificates from the given PEM data.
+// The PEM certificates must be concatenated.  This function can be used for
+// parsing PEM-formatted certificate chains, but does not verify that the
+// resulting chain is a valid certificate chain.
+func CertificatesFromPEM(pemBytes []byte) ([]*x509.Certificate, error) {
+	var chain []*x509.Certificate
+	for {
+		var block *pem.Block
+		block, pemBytes = pem.Decode(pemBytes)
+		if block == nil {
+			return chain, nil
+		}
+		if block.Type != "CERTIFICATE" {
+			return nil, fmt.Errorf("PEM block is not a CERTIFICATE")
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, errors.New("failed to parse certificate")
+		}
+		chain = append(chain, cert)
+	}
+}
+
+// ParseSCTsFromSCTList parses each of the SCTs contained within an SCT list.
+func ParseSCTsFromSCTList(sctList *x509.SignedCertificateTimestampList) ([]*ct.SignedCertificateTimestamp, error) {
+	var scts []*ct.SignedCertificateTimestamp
+	for i, data := range sctList.SCTList {
+		sct, err := ExtractSCT(&data)
+		if err != nil {
+			return nil, fmt.Errorf("error extracting SCT number %d: %s", i, err)
+		}
+		scts = append(scts, sct)
+	}
+	return scts, nil
+}
+
+// ExtractSCT deserializes an SCT from a TLS-encoded SCT.
+func ExtractSCT(sctData *x509.SerializedSCT) (*ct.SignedCertificateTimestamp, error) {
+	if sctData == nil {
+		return nil, errors.New("SCT is nil")
+	}
+	var sct ct.SignedCertificateTimestamp
+	if rest, err := tls.Unmarshal(sctData.Val, &sct); err != nil {
+		return nil, fmt.Errorf("error parsing SCT: %s", err)
+	} else if len(rest) > 0 {
+		return nil, fmt.Errorf("extra data (%d bytes) after serialized SCT", len(rest))
+	}
+	return &sct, nil
+}
+
+// MarshalSCTsIntoSCTList serializes SCTs into SCT list.
+func MarshalSCTsIntoSCTList(scts []*ct.SignedCertificateTimestamp) (*x509.SignedCertificateTimestampList, error) {
+	var sctList x509.SignedCertificateTimestampList
+	sctList.SCTList = []x509.SerializedSCT{}
+	for i, sct := range scts {
+		if sct == nil {
+			return nil, fmt.Errorf("SCT number %d is nil", i)
+		}
+		encd, err := tls.Marshal(*sct)
+		if err != nil {
+			return nil, fmt.Errorf("error serializing SCT number %d: %s", i, err)
+		}
+		sctData := x509.SerializedSCT{Val: encd}
+		sctList.SCTList = append(sctList.SCTList, sctData)
+	}
+	return &sctList, nil
+}
+
+var pemCertificatePrefix = []byte("-----BEGIN CERTIFICATE")
+
+// ParseSCTsFromCertificate parses any SCTs that are embedded in the
+// certificate provided.  The certificate bytes provided can be either DER or
+// PEM, provided the PEM data starts with the PEM block marker (i.e. has no
+// leading text).
+func ParseSCTsFromCertificate(certBytes []byte) ([]*ct.SignedCertificateTimestamp, error) {
+	var cert *x509.Certificate
+	var err error
+	if bytes.HasPrefix(certBytes, pemCertificatePrefix) {
+		cert, err = CertificateFromPEM(certBytes)
+	} else {
+		cert, err = x509.ParseCertificate(certBytes)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate: %s", err)
+	}
+	return ParseSCTsFromSCTList(&cert.SCTList)
+}


### PR DESCRIPTION
Towards #106 and #44.

This will allow to migrate off the c-t-go/x509, tls and asn1 librairies in a followup PR.

This PR only carries over x509util/ internals that we actually need in this repo, it's not a 100% copy of #106 and #44. I did consider not moving cert_pool, but it turned out to be a bit harder than I originally thought because of the way that the library has evolved under crypto/. Let's move it now, and improve it later.

After this PR, I'll migrate ~everything in this repo away from the c-t-go/x509, tls and asn1 libraries. That will allow to get rid of  the printing methods that this PR moves over in x509util.

To allow for all go static checks to pass, I've removed dsa support, and some printing support for ECDSA. These small edits won't be relevant anymore, after the next PRs will have stripped x509util down.