### PR TITLE
[GCP] Remove `project_id` from Cloud Run container arguments

### DIFF
--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -41,7 +41,6 @@ resource "google_cloud_run_v2_service" "default" {
         "--logtostderr",
         "--v=1",
         "--http_endpoint=:6962",
-        "--project_id=${var.project_id}",
         "--bucket=${var.bucket}",
         "--spanner_db_path=${local.spanner_log_db_path}",
         "--spanner_dedup_db_path=${local.spanner_dedup_db_path}",


### PR DESCRIPTION
Towards https://github.com/transparency-dev/static-ct/issues/122.

The project_id flag was removed in https://github.com/transparency-dev/static-ct/commit/72abfe52d4826c811f78869709a0d9c4d2e1813e. However, the Terraform config still provides the flag.