### PR TITLE
Fix incorrect testdata directory in GCP CloudBuild

### DIFF
--- a/deployment/modules/gcp/cloudbuild/main.tf
+++ b/deployment/modules/gcp/cloudbuild/main.tf
@@ -157,9 +157,9 @@ resource "google_cloudbuild_trigger" "build_trigger" {
         apt update && apt install jq -y
         mkdir -p /tmp/httpschain
         openssl genrsa -out /tmp/httpschain/cert.key 2048
-        openssl req -new -key /tmp/httpschain/cert.key -out /tmp/httpschain/cert.csr -config=testdata/fake-ca.cfg
-        openssl x509 -req -days 3650 -in /tmp/httpschain/cert.csr -CAkey testdata/fake-ca.privkey.pem -CA testdata/fake-ca.cert -passin pass:"gently" -outform pem -out /tmp/httpschain/chain.pem -provider legacy -provider default
-        cat testdata/fake-ca.cert >> /tmp/httpschain/chain.pem
+        openssl req -new -key /tmp/httpschain/cert.key -out /tmp/httpschain/cert.csr -config=internal/testdata/fake-ca.cfg
+        openssl x509 -req -days 3650 -in /tmp/httpschain/cert.csr -CAkey internal/testdata/fake-ca.privkey.pem -CA internal/testdata/fake-ca.cert -passin pass:"gently" -outform pem -out /tmp/httpschain/chain.pem -provider legacy -provider default
+        cat internal/testdata/fake-ca.cert >> /tmp/httpschain/chain.pem
         cat /tmp/httpschain/chain.pem | jq --raw-input --slurp --compact-output 'split("\n-----END CERTIFICATE-----\n") | map(select(length > 0) | sub("^-----BEGIN CERTIFICATE-----\n"; "") | sub("\n-----END CERTIFICATE-----$"; "")) | { "chain": . }' > /tmp/httpschain/chain.json
         curl -s -o /tmp/add_chain_response_body -w "%%{http_code}" -X POST --data @/tmp/httpschain/chain.json -H "Content-Type: application/json" -H "Authorization: Bearer $(cat /workspace/cb_identity)" $(cat /workspace/conformance_url)/ci-${var.project_id}/ct/v1/add-chain > /tmp/add_chain_response_code
 


### PR DESCRIPTION
Towards #122.

```
Can't open "testdata/fake-ca.cfg" for reading, No such file or directory
40A7B44C2C7F0000:error:80000002:system library:BIO_new_file:No such file or directory:../crypto/bio/bss_file.c:67:calling fopen(testdata/fake-ca.cfg, r)
40A7B44C2C7F0000:error:10000080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:75:
Can't open "/tmp/httpschain/cert.csr" for reading, No such file or directory
403770FE067F0000:error:80000002:system library:BIO_new_file:No such file or directory:../crypto/bio/bss_file.c:67:calling fopen(/tmp/httpschain/cert.csr, r)
403770FE067F0000:error:10000080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:75:
Unable to load certificate request input
cat: testdata/fake-ca.cert: No such file or directory
404
404 page not found
Error: File does not contain 200 status OK
```