### PR TITLE
Remove debug log to troubleshoot `curl_test`

### DIFF
--- a/deployment/modules/gcp/cloudbuild/main.tf
+++ b/deployment/modules/gcp/cloudbuild/main.tf
@@ -156,11 +156,6 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       script   = <<EOT
         apt update && apt install jq -y
 
-        pwd
-        ls -la ./testdata
-        ls -la ./internal
-        ls -la ./internal/testdata
-
         mkdir -p /tmp/httpschain
         openssl genrsa -out /tmp/httpschain/cert.key 2048
         openssl req -new -key /tmp/httpschain/cert.key -out /tmp/httpschain/cert.csr -config=internal/testdata/fake-ca.cfg


### PR DESCRIPTION
Towards #122.

Ah, I forgot to `terragrunt apply` to deploy the GCP cloud build changes. We should be good to revert the debug log.