### PR TITLE
Replace curl_test with CT Hammer in GCP Cloud Build

### DIFF
--- a/cmd/gcp/ci/Dockerfile
+++ b/cmd/gcp/ci/Dockerfile
@@ -3,8 +3,8 @@ FROM sctfe-gcp:latest AS base
 # Build release image
 FROM alpine:3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
 
-# Copy the fake CA certificate into the container
-COPY ./internal/testdata/fake-ca.cert /bin/
+# Copy the hammer test root CA certificate into the container
+COPY ./internal/hammer/testdata/test_root_ca_cert.pem /bin/
 
 # Copy the sctfe-gcp binary
 COPY --from=base /bin/sctfe-gcp /bin/

--- a/deployment/live/gcp/cloudbuild/README.md
+++ b/deployment/live/gcp/cloudbuild/README.md
@@ -8,7 +8,7 @@ is responsible for:
 1. Building the `cmd/gcp` and `cmd/gcp/ci` docker images from the `main` branch,
 1. Deploying the `cmd/gcp/ci` image to Cloud Run,
 1. Creating a fresh conformance testing environment,
-1. Running the conformance test (TODO: with CT Hammer) against the newly build conformance docker image,
+1. Running the conformance test with [CT Hammer](/internal/hammer/) against the newly build conformance docker image,
 1. Turning-down the conformance testing environment.
 
 ## Initial setup

--- a/deployment/modules/gcp/cloudbuild/main.tf
+++ b/deployment/modules/gcp/cloudbuild/main.tf
@@ -126,7 +126,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
         terragrunt --terragrunt-non-interactive --terragrunt-no-color apply -auto-approve -no-color 2>&1
         terragrunt --terragrunt-no-color output --raw conformance_url -no-color > /workspace/conformance_url
         terragrunt --terragrunt-no-color output --raw conformance_bucket_name -no-color > /workspace/conformance_bucket_name
-        terragrunt --terragrunt-no-color output --raw ecdsa_p256_public_key_secret_data -no-color > /workspace/conformance_log_public_key.pem
+        terragrunt --terragrunt-no-color output --raw ecdsa_p256_public_key_data -no-color > /workspace/conformance_log_public_key.pem
       EOT
       dir    = "deployment/live/gcp/ci"
       env = [

--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -44,7 +44,7 @@ resource "google_cloud_run_v2_service" "default" {
         "--bucket=${var.bucket}",
         "--spanner_db_path=${local.spanner_log_db_path}",
         "--spanner_dedup_db_path=${local.spanner_dedup_db_path}",
-        "--roots_pem_file=/bin/fake-ca.cert",
+        "--roots_pem_file=/bin/test_root_ca_cert.pem",
         "--origin=${var.base_name}",
         "--signer_public_key_secret_name=${var.signer_public_key_secret_name}",
         "--signer_private_key_secret_name=${var.signer_private_key_secret_name}",

--- a/deployment/modules/gcp/conformance/outputs.tf
+++ b/deployment/modules/gcp/conformance/outputs.tf
@@ -3,6 +3,12 @@ output "ecdsa_p256_public_key_id" {
   value       = module.secretmanager.ecdsa_p256_public_key_id
 }
 
+output "ecdsa_p256_public_key_secret_data" {
+  description = "Signer public key (P256_SHA256) secret data"
+  value       = module.secretmanager.ecdsa_p256_public_key_secret_data
+  sensitive   = true
+}
+
 output "ecdsa_p256_private_key_id" {
   description = "Signer private key (P256_SHA256)"
   value       = module.secretmanager.ecdsa_p256_private_key_id
@@ -11,4 +17,9 @@ output "ecdsa_p256_private_key_id" {
 output "conformance_url" {
   description = "The URL of the running conformance server"
   value       = module.cloudrun.conformance_url
+}
+
+output "conformance_bucket_name" {
+  description = "The GCS bucket name of the running conformance server"
+  value       = module.storage.log_bucket.name
 }

--- a/deployment/modules/gcp/conformance/outputs.tf
+++ b/deployment/modules/gcp/conformance/outputs.tf
@@ -3,9 +3,9 @@ output "ecdsa_p256_public_key_id" {
   value       = module.secretmanager.ecdsa_p256_public_key_id
 }
 
-output "ecdsa_p256_public_key_secret_data" {
-  description = "Signer public key (P256_SHA256) secret data"
-  value       = module.secretmanager.ecdsa_p256_public_key_secret_data
+output "ecdsa_p256_public_key_data" {
+  description = "Signer public key (P256_SHA256) data from secret manager"
+  value       = module.secretmanager.ecdsa_p256_public_key_data
   sensitive   = true
 }
 

--- a/deployment/modules/gcp/secretmanager/outputs.tf
+++ b/deployment/modules/gcp/secretmanager/outputs.tf
@@ -3,8 +3,8 @@ output "ecdsa_p256_public_key_id" {
   value       = google_secret_manager_secret_version.sctfe_ecdsa_p256_public_key.id
 }
 
-output "ecdsa_p256_public_key_secret_data" {
-  description = "Signer public key (P256_SHA256) secret data"
+output "ecdsa_p256_public_key_data" {
+  description = "Signer public key (P256_SHA256) data from secret manager"
   value       = google_secret_manager_secret_version.sctfe_ecdsa_p256_public_key.secret_data
   sensitive   = true
 }

--- a/deployment/modules/gcp/secretmanager/outputs.tf
+++ b/deployment/modules/gcp/secretmanager/outputs.tf
@@ -3,6 +3,12 @@ output "ecdsa_p256_public_key_id" {
   value       = google_secret_manager_secret_version.sctfe_ecdsa_p256_public_key.id
 }
 
+output "ecdsa_p256_public_key_secret_data" {
+  description = "Signer public key (P256_SHA256) secret data"
+  value       = google_secret_manager_secret_version.sctfe_ecdsa_p256_public_key.secret_data
+  sensitive   = true
+}
+
 output "ecdsa_p256_private_key_id" {
   description = "Signer private key (P256_SHA256)"
   value       = google_secret_manager_secret_version.sctfe_ecdsa_p256_private_key.id

--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -358,8 +358,8 @@ func verifySupportedKeyAlgorithm(key any) error {
 	}
 }
 
-// logSigVerifier creates a note.Verifier for the Static CT API log by taking
-// an origin string and a base64-encoded public key.
+// logSigVerifier creates a note.Verifier for the Trillian Log by taking an
+// origin string and a base64-encoded public key.
 func logSigVerifier(origin, b64PubKey string) (note.Verifier, error) {
 	if origin == "" {
 		return nil, errors.New("origin cannot be empty")

--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -358,8 +358,8 @@ func verifySupportedKeyAlgorithm(key any) error {
 	}
 }
 
-// logSigVerifier creates a note.Verifier for the Trillian Log by taking an
-// origin string and a base64-encoded public key.
+// logSigVerifier creates a note.Verifier for the Static CT API log by taking
+// an origin string and a base64-encoded public key.
 func logSigVerifier(origin, b64PubKey string) (note.Verifier, error) {
 	if origin == "" {
 		return nil, errors.New("origin cannot be empty")


### PR DESCRIPTION
Towards #59.

Retrieving the CT log public key secret data immediately after the `terragrunt apply` is probably the only way. This is because the key secrets are not available before the Cloud Build is triggered.

The following ways are considered but they do not work.

```
    available_secrets {
      secret_manager {
        env          = "CT_LOG_PUBLIC_KEY"
        version_name = "projects/${var.project_id}/secrets/${var.base_name}-ecdsa-p256-public-key/versions/1"
      }
    }
```

```
data "google_secret_manager_secret_version_access" "ct_log_public_key" {
  secret = "${var.base_name}-ecdsa-p256-public-key"
}
```