### PR TITLE
update certs for pre-issuer tests

### DIFF
--- a/internal/scti/chain_validation_test.go
+++ b/internal/scti/chain_validation_test.go
@@ -15,7 +15,6 @@
 package scti
 
 import (
-	"encoding/base64"
 	"encoding/pem"
 	"strings"
 	"testing"
@@ -491,29 +490,40 @@ func pemFileToDERChain(t *testing.T, filename string) [][]byte {
 	return rawChain
 }
 
-// Validate a chain including a pre-issuer as produced by Google's Compliance Monitor.
-func TestCMPreIssuedCert(t *testing.T) {
-	var b64Chain = []string{
-		"MIID+jCCAuKgAwIBAgIHBWW7shJizTANBgkqhkiG9w0BAQsFADB1MQswCQYDVQQGEwJHQjEPMA0GA1UEBwwGTG9uZG9uMTowOAYDVQQKDDFHb29nbGUgQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IChQcmVjZXJ0IFNpZ25pbmcpMRkwFwYDVQQFExAxNTE5MjMxNzA0MTczNDg3MB4XDTE4MDIyMTE2NDgyNFoXDTE4MTIwMTIwMzMyN1owYzELMAkGA1UEBhMCR0IxDzANBgNVBAcMBkxvbmRvbjEoMCYGA1UECgwfR29vZ2xlIENlcnRpZmljYXRlIFRyYW5zcGFyZW5jeTEZMBcGA1UEBRMQMTUxOTIzMTcwNDM5MjM5NzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKnKP9TP6hkEuD+d1rPeA8mxo5xFYffhCcEitP8PtTl7G2RqFrndPeAkzgvOxPB3Jrhx7LtMtg0IvS8y7Sy1qDqDou1/OrJgwCeWMc1/KSneuGP8GTX0Rqy4z8+LsiBN/tMDbt94RuiyCeltIAaHGmsNeYXV34ayD3vSIAQbtLUOD39KqrJWO0tQ//nshBuFlebiUrDP7rirPusYYW0stJKiCKeORhHvL3/I8mCYGNO0XIWMpASH2S9LGMwg+AQM13whC1KL65EGuVs4Ta0rO+Tl8Yi0is0RwdUmgdSGtl0evPTzyUXbA1n1BpkLcSQ5E3RxY3O6Ge9Whvtmg9vAJiMCAwEAAaOBoDCBnTATBgNVHSUEDDAKBggrBgEFBQcDATAjBgNVHREEHDAaghhmbG93ZXJzLXRvLXRoZS13b3JsZC5jb20wDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBRKCM/Ajh0Fu6FFjJ9F4gVWK2oj/jAdBgNVHQ4EFgQUVjYl6wDey3DxvmTG2HL4vdiUt+MwEwYKKwYBBAHWeQIEAwEB/wQCBQAwDQYJKoZIhvcNAQELBQADggEBAAvyEFDIAWr0URsZzrJLZEL8p6FMTzVxY/MOvGP8QMXA6xNVElxYnDPF32JERAl+poR7syByhVFcEjrw7f2FTlMc04+hT/hsYzi8cMAmfX9KA36xUBVjyqvqwofxTwoWYdf+eGZW0EG8Yp1pM7iUy9bdlh3sgdOpmT9Z5XGCRwvdW1+mctv0JMKDdWzxBqYyNMnNjvjHBmkiuHeDDGFsV2zq+wV64RwJa2eVrnkMDMV1mscL6KzNRLPP2ZpNz/8H7SPock+fk4cZrdqj+0IzFt+6ixSoKyltyD+nkbWjRGY4iyboo/nPgTQ1IQCS2OPVHWw3NijFD8hqgAnYvz0Dn+k=",
-		"MIIE4jCCAsqgAwIBAgIHBWW7sg8LrzANBgkqhkiG9w0BAQUFADB/MQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMRcwFQYDVQQKDA5Hb29nbGUgVUsgTHRkLjEhMB8GA1UECwwYQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5MSMwIQYDVQQDDBpNZXJnZSBEZWxheSBJbnRlcm1lZGlhdGUgMTAeFw0xODAyMjExNjQ4MjRaFw0xODEyMDEyMDM0MjdaMHUxCzAJBgNVBAYTAkdCMQ8wDQYDVQQHDAZMb25kb24xOjA4BgNVBAoMMUdvb2dsZSBDZXJ0aWZpY2F0ZSBUcmFuc3BhcmVuY3kgKFByZWNlcnQgU2lnbmluZykxGTAXBgNVBAUTEDE1MTkyMzE3MDQxNzM0ODcwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCKWlc3A43kJ9IzmkCPXcsGwTxlIvtl9sNYBWlx9qqHa1i6tU6rZuH9uXAb3wsn39fqY22HzF/yrx9pd05doFfRq6dvvm4eHNFfFm4cJur1kmPe8vLKpSI/P2DPx4/mRzrHnPAI8Jo9QgKcj91AyYeB689ZFzH30ay32beo6PxQvtoJkzl+dzf9Hs1ezavS7nDCuqDnu1V1Og7J5xTHZeNyTKgD5Kx28ukmIp2wGOvg3omuInABg/ew0VxnG/txKV+69zfV9dhclU3m16L81e3RkJ8Kg4RLb0mh9X3EMn90SpJ9yw0j8FF0Esk6wxuYeUGLShUji8BPnnbactY9B6ORAgMBAAGjbTBrMBgGA1UdJQEB/wQOMAwGCisGAQQB1nkCBAQwDwYDVR0TAQH/BAUwAwEB/zAfBgNVHSMEGDAWgBTpPAThgC/ChBMtJnCe8v0az6r+xjAdBgNVHQ4EFgQUSgjPwI4dBbuhRYyfReIFVitqI/4wDQYJKoZIhvcNAQEFBQADggIBAEep2uWAFsdq1nLtLWLGh7DfVPc/K+1lcqNx64ucjpVZbDnMnYKFagf2Z9rHEWqR7kwuLac5xW8woSlLa/NHmJmdg18HGUhlS+x8iMPv7dK6hfNsRFdjLZkZOFneuf9j1b0dV+rXoRvyY+Oq+lomC98bEr+g9zq+M7wJ4wS/KeaNHpPw1pBeTtCdw+1c4ZgRTOEa2OUUpkpueJ+9psD/hbp6HLF+WYijWQ0/iYSxJ4TbjTC+omKRsGhvxSLbP8cSMt3X1pJgrFK1BvH4lqqEXGDNEiVNoPCHraEa8JtMZIo47/Af13lDfp6sBdZ0lvLAVDduWgg/2RkWCbHefAe81h+cYdDS775TF2TCMTwsR6GsM9sVCbfPvHXI/pUzamRn0i0CrhyccBBdPrUhj+cXuc9kqSkLegun9D8EBDMM9va5wb1HM0ruSno+YuLtfhCdBRHr/RG2BKJi7uUDjJ8goHov/EUJmHjAIARKz74IPWRkxMrnOvGhnNa2Hz+da3hpusz0Mj4rsqv1EKTC2wbCs6Rk2MRPSxdRbywdWLSmGn249SMfXK4An+dqoRk1fwKqdXc4swoUvxnGUi5ajBaRtc6631zBTmvmSFQnvGmS42aF7q2PjfvWPIuO+d//m8KgN6o2YyjrdPDDslI2RZUE5ngOR+JynvhjYrrB7Bat1EY7",
-		"MIIFyDCCA7CgAwIBAgICEAEwDQYJKoZIhvcNAQEFBQAwfTELMAkGA1UEBhMCR0IxDzANBgNVBAgMBkxvbmRvbjEXMBUGA1UECgwOR29vZ2xlIFVLIEx0ZC4xITAfBgNVBAsMGENlcnRpZmljYXRlIFRyYW5zcGFyZW5jeTEhMB8GA1UEAwwYTWVyZ2UgRGVsYXkgTW9uaXRvciBSb290MB4XDTE0MDcxNzEyMjYzMFoXDTE5MDcxNjEyMjYzMFowfzELMAkGA1UEBhMCR0IxDzANBgNVBAgMBkxvbmRvbjEXMBUGA1UECgwOR29vZ2xlIFVLIEx0ZC4xITAfBgNVBAsMGENlcnRpZmljYXRlIFRyYW5zcGFyZW5jeTEjMCEGA1UEAwwaTWVyZ2UgRGVsYXkgSW50ZXJtZWRpYXRlIDEwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDB6HT+/5ru8wO7+mNFOIH6r43BwiwJZB2vQwOB8zvBV79sTIqNV7Grx5KFnSDyGRUJxZfEN7FGc96lr0vqFDlt1DbcYgVV15U+Dt4B9/+0Tz/3zeZO0kVjTg3wqvzpw6xetj2N4dlpysiFQZVAOp+dHUw9zu3xNR7dlFdDvFSrdFsgT7Uln+Pt9pXCz5C4hsSP9oC3RP7CaRtDRSQrMcNvMRi3J8XeXCXsGqMKTCRhxRGe9ruQ2Bbm5ExbmVW/ou00Fr9uSlPJL6+sDR8Li/PTW+DU9hygXSj8Zi36WI+6PuA4BHDAEt7Z5Ru/Hnol76dFeExJ0F6vjc7gUnNh7JExJgBelyz0uGORT4NhWC7SRWP/ngPFLoqcoyZMVsGGtOxSt+aVzkKuF+x64CVxMeHb9I8t3iQubpHqMEmIE1oVSCsF/AkTVTKLOeWG6N06SjoUy5fu9o+faXKMKR8hldLM5z1K6QhFsb/F+uBAuU/DWaKVEZgbmWautW06fF5I+OyoFeW+hrPTbmon4OLE3ubjDxKnyTa4yYytWSisojjfw5z58sUkbLu7KAy2+Z60m/0deAiVOQcsFkxwgzcXRt7bxN7By5Q5Bzrz8uYPjFBfBnlhqMU5RU/FNBFY7Mx4Uy8+OcMYfJQ5/A/4julXEx1HjfBj3VCyrT/noHDpBeOGiwIDAQABo1AwTjAdBgNVHQ4EFgQU6TwE4YAvwoQTLSZwnvL9Gs+q/sYwHwYDVR0jBBgwFoAU8197dUnjeEE5aiC2fGtMXMk9WEEwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAgEACFjL1UXy6S4JkGrDnz1VwTYHplFDY4bG6Q8Sh3Og6z9HJdivNft/iAQ2tIHyz0eAGCXeVPE/j1kgvz2RbnUxQd5eWdLeu/w/wiZyHxWhbTt6RhjqBVFjnx0st7n6rRt+Bw8jpugZfD11SbumVT/V20Gc45lHf2oEgbkPUcnTB9gssFz5Z4KKGs5lIHz4a20WeSJF3PJLTBefkRhHNufi/LhjpLXImwrC82g5ChBZS5XIVuJZx3VkMWiYz4emgX0YWF/JdtaB2dUQ7yrTforQ5J9b1JnJ7H/o9DsX3/ubfQ39gwDBxTicnqC+Q3Dcv3i9PvwjCNJQuGa7ygMcDEn/d6elQg2qHxtqRE02ZlOXTC0XnDAJhx7myJFA/Knv3yO9S4jG6665KG9Y88/CHkh08YLR7NYFiRmwOxjbe3lb6csl/FFmqUXvjhEzzWAxKjI09GSd9hZkB8u17Mg46eEYwF3ufIlqmYdlWufjSc2BZuaNNN6jtK6JKp8jhQUycehgtUK+NlBQOXTzu28miDdasoSH2mdR0PLDo1547+MLGdV4COvqLERTmQrYHrliicD5nFCA+CCSvGEjo0DGOmF/O8StwSmNiKJ4ppPvk2iGEdO07e0LbQI+2fbC6og2SDGXUlsbG85wqQw0A7CU1fQSqhFBuZZauDFMUvdy3v/BAIw=",
-		"MIIFzTCCA7WgAwIBAgIJAJ7TzLHRLKJyMA0GCSqGSIb3DQEBBQUAMH0xCzAJBgNVBAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xFzAVBgNVBAoMDkdvb2dsZSBVSyBMdGQuMSEwHwYDVQQLDBhDZXJ0aWZpY2F0ZSBUcmFuc3BhcmVuY3kxITAfBgNVBAMMGE1lcmdlIERlbGF5IE1vbml0b3IgUm9vdDAeFw0xNDA3MTcxMjA1NDNaFw00MTEyMDIxMjA1NDNaMH0xCzAJBgNVBAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xFzAVBgNVBAoMDkdvb2dsZSBVSyBMdGQuMSEwHwYDVQQLDBhDZXJ0aWZpY2F0ZSBUcmFuc3BhcmVuY3kxITAfBgNVBAMMGE1lcmdlIERlbGF5IE1vbml0b3IgUm9vdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKoWHPIgXtgaxWVIPNpCaj2y5Yj9t1ixe5PqjWhJXVNKAbpPbNHA/AoSivecBm3FTD9DfgW6J17mHb+cvbKSgYNzgTk5e2GJrnOP7yubYJpt2OCw0OILJD25NsApzcIiCvLA4aXkqkGgBq9FiVfisReNJxVu8MtxfhbVQCXZf0PpkW+yQPuF99V5Ri+grHbHYlaEN1C/HM3+t2yMR4hkd2RNXsMjViit9qCchIi/pQNt5xeQgVGmtYXyc92ftTMrmvduj7+pHq9DEYFt3ifFxE8v0GzCIE1xR/d7prFqKl/KRwAjYUcpU4vuazywcmRxODKuwWFVDrUBkGgCIVIjrMJWStH5i7WTSSTrVtOD/HWYvkXInZlSgcDvsNIG0pptJaEKSP4jUzI3nFymnoNZn6pnfdIII/XISpYSVeyl1IcdVMod8HdKoRew9CzW6f2n6KSKU5I8X5QEM1NUTmRLWmVi5c75/CvS/PzOMyMzXPf+fE2Dwbf4OcR5AZLTupqp8yCTqo7ny+cIBZ1TjcZjzKG4JTMaqDZ1Sg0T3mO/ZbbiBE3N8EHxoMWpw8OP50z1dtRRwj6qUZ2zLvngOb2EihlMO15BpVZC3Cg929c9Hdl65pUd4YrYnQBQB/rn6IvHo8zot8zElgOg22fHbViijUt3qnRggB40N30MXkYGwuJbAgMBAAGjUDBOMB0GA1UdDgQWBBTzX3t1SeN4QTlqILZ8a0xcyT1YQTAfBgNVHSMEGDAWgBTzX3t1SeN4QTlqILZ8a0xcyT1YQTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUAA4ICAQB3HP6jRXmpdSDYwkI9aOzQeJH4x/HDi/PNMOqdNje/xdNzUy7HZWVYvvSVBkZ1DG/ghcUtn/wJ5m6/orBn3ncnyzgdKyXbWLnCGX/V61PgIPQpuGo7HzegenYaZqWz7NeXxGaVo3/y1HxUEmvmvSiioQM1cifGtz9/aJsJtIkn5umlImenKKEV1Ly7R3Uz3Cjz/Ffac1o+xU+8NpkLF/67fkazJCCMH6dCWgy6SL3AOB6oKFIVJhw8SD8vptHaDbpJSRBxifMtcop/85XUNDCvO4zkvlB1vPZ9ZmYZQdyL43NA+PkoKy0qrdaQZZMq1Jdp+Lx/yeX255/zkkILp43jFyd44rZ+TfGEQN1WHlp4RMjvoGwOX1uGlfoGkRSgBRj7TBn514VYMbXu687RS4WY2v+kny3PUFv/ZBfYSyjoNZnU4Dce9kstgv+gaKMQRPcyL+4vZU7DV8nBIfNFilCXKMN/VnNBKtDV52qmtOsVghgai+QE09w15x7dg+44gIfWFHxNhvHKys+s4BBN8fSxAMLOsb5NGFHE8x58RAkmIYWHjyPM6zB5AUPw1b2A0sDtQmCqoxJZfZUKrzyLz8gS2aVujRYN13KklHQ3EKfkeKBG2KXVBe5rjMN/7Anf1MtXxsTY6O8qIuHZ5QlXhSYzE41yIlPlG6d7AGnTiBIgeg==",
-	}
-	rawChain := make([][]byte, len(b64Chain))
-	for i, b64Data := range b64Chain {
-		var err error
-		rawChain[i], err = base64.StdEncoding.DecodeString(b64Data)
-		if err != nil {
-			t.Fatalf("failed to base64.Decode(chain[%d]): %v", i, err)
+// chainFromPEMs builds a chain from a list of PEMs.
+func chainFromPEMs(t *testing.T, pems ...string) [][]byte {
+	t.Helper()
+	var chain [][]byte
+	for _, p := range pems {
+		pb := []byte(p)
+		for len(p) > 0 {
+			var block *pem.Block
+			block, pb = pem.Decode(pb)
+			if block == nil {
+				break
+			}
+			if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+				continue
+			}
+			chain = append(chain, block.Bytes)
 		}
 	}
 
-	root, err := x509.ParseCertificate(rawChain[len(rawChain)-1])
-	if err != nil {
-		t.Fatalf("failed to parse root cert: %v", err)
+	return chain
+}
+
+// Validate a chain including a pre-issuer.
+func TestPreIssuedCert(t *testing.T) {
+	// TODO(phboneff): add a test to make sure that a pre-isser can't sign an end cert.
+	rawChain := chainFromPEMs(t, []string{
+		testdata.PreCertFromPreIntermediate,
+		testdata.PreIntermediateFromRoot,
+		testdata.CACertPEM}...)
+
+	roots := x509util.NewPEMCertPool()
+	if ok := roots.AppendCertsFromPEM([]byte(testdata.CACertPEM)); !ok {
+		t.Fatalf("failed to parse root cert")
 	}
-	cmRoot := x509util.NewPEMCertPool()
-	cmRoot.AddCert(root)
 
 	for _, tc := range []struct {
 		desc string
@@ -528,7 +538,7 @@ func TestCMPreIssuedCert(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			opts := ChainValidationOpts{
-				trustedRoots: cmRoot,
+				trustedRoots: roots,
 				extKeyUsages: tc.eku,
 			}
 			chain, err := validateChain(rawChain, opts)

--- a/internal/testdata/certificates.go
+++ b/internal/testdata/certificates.go
@@ -16,8 +16,7 @@ package testdata
 
 import _ "embed"
 
-// This file holds test certificates. It contain four independent issuance
-// chains.
+// This file holds test certificates. It contain five issuance chains.
 // TODO(phboneff): clean this and make use of a single chain if possible.
 
 // Issuance chain 1
@@ -176,8 +175,120 @@ var TestCertPEM string
 
 // Issuance chain 2
 // ================
-// The next section holds a self signed root, an intermediate, and a leaf cert.
+// The next section holds:
+//   - an intermediate with the CT preissuer bit signed with the root above.
+//   - a pre-cert issued by this intermediate
 
+// PreIntermdiateFromRoot is an intermediate with the CT preissuer bit signed
+// with the root above.
+//
+// $ openssl x509  -in internal/testdata/test_pre_intermediate_ca_cert.pem -noout -text
+//
+// Data:
+//
+//	Version: 3 (0x2)
+//	Serial Number: 2 (0x2)
+//	Signature Algorithm: ecdsa-with-SHA384
+//	Issuer: C=GB, O=TrustFabric Transparency.dev Test Root Test CA, CN=TrustFabric Transparency.dev Test Root Test CA
+//	Validity
+//	    Not Before: Dec  5 18:05:50 2024 GMT
+//	    Not After : Dec  5 18:05:50 2029 GMT
+//	Subject: C=GB, O=TrustFabric Transparency.dev Test Intermediate Test CA, CN=TrustFabric Transparency.dev Test Intermediate Test CA
+//	Subject Public Key Info:
+//	    Public Key Algorithm: id-ecPublicKey
+//	        Public-Key: (384 bit)
+//	        pub:
+//	            04:3d:e3:59:7a:d0:8b:55:a7:96:30:88:6e:ba:2c:
+//	            60:d5:30:38:b3:e9:da:62:19:c0:1f:b5:12:c2:fe:
+//	            77:59:77:30:47:e3:e1:36:02:9b:5c:9c:7e:65:aa:
+//	            56:76:91:02:0f:d8:64:aa:40:41:5e:19:fa:b2:39:
+//	            de:13:a6:ee:1b:96:34:91:67:36:7e:7c:2f:cc:8e:
+//	            c0:7f:e9:fb:b6:fa:d9:f9:1f:ed:3c:18:59:4d:a0:
+//	            ab:ee:11:e3:f0:2c:87
+//	        ASN1 OID: secp384r1
+//	        NIST CURVE: P-384
+//	X509v3 extensions:
+//	    X509v3 Key Usage: critical
+//	        Certificate Sign, CRL Sign
+//	    X509v3 Basic Constraints: critical
+//	        CA:TRUE
+//	    X509v3 Subject Key Identifier:
+//	        1F:FE:3D:85:AC:F5:38:C7:90:1C:6C:EA:E7:5F:45:74:83:CC:95:39
+//	    X509v3 Authority Key Identifier:
+//	        77:1D:7C:21:61:2D:C2:05:7D:AA:30:1E:6B:7F:8F:9B:DC:61:20:68
+//	    CT Precertificate Signer:
+//
+// Signature Algorithm: ecdsa-with-SHA384
+// Signature Value:
+//
+//	30:66:02:31:00:a1:62:a6:36:99:62:27:f4:e7:8b:9b:5e:ff:
+//	80:4c:75:39:04:cc:80:d7:64:12:09:e8:80:e6:10:af:24:81:
+//	2a:59:17:7a:58:da:6f:ca:f3:46:d3:5b:5c:e6:e1:dd:9c:02:
+//	31:00:dd:c8:3a:b9:5d:9c:08:3c:27:73:11:17:fe:7a:82:98:
+//	79:f8:a3:e3:16:54:c5:9f:79:d7:4f:1a:e2:55:48:d1:87:f2:
+//	ab:2f:ad:81:dd:6e:b9:fc:59:77:37:6e:6e:75
+//
+//go:embed test_pre_intermediate_ca_cert.pem
+var PreIntermediateFromRoot string
+
+// PreCertFromPreIntermediate is a pre-cert issued by PreIntermediateFromRoot.
+//
+// $ openssl x509  -in internal/testdata/test_leaf_pre_cert_signed_by_pre_intermediate.pem -noout -text
+//
+// Data:
+//
+//	Version: 3 (0x2)
+//	Serial Number: 200 (0xc8)
+//	Signature Algorithm: ecdsa-with-SHA384
+//	Issuer: C=GB, O=TrustFabric Transparency.dev Test Intermediate Test CA, CN=TrustFabric Transparency.dev Test Intermediate Test CA
+//	Validity
+//	    Not Before: Dec  5 18:05:50 2024 GMT
+//	    Not After : Dec  5 18:05:50 2025 GMT
+//	Subject: C=GB, ST=London, L=London, O=TrustFabric Transparency.dev Test, OU=TrustFabric, CN=test.transparency.dev
+//	Subject Public Key Info:
+//	    Public Key Algorithm: id-ecPublicKey
+//	        Public-Key: (384 bit)
+//	        pub:
+//	            04:46:10:60:6d:e5:70:0d:fa:8f:ea:8c:70:40:6e:
+//	            eb:dd:15:88:8a:6e:94:54:ac:f7:92:77:53:68:65:
+//	            c1:55:d4:c0:92:2e:b4:08:d9:07:50:d3:12:f4:fb:
+//	            56:08:ff:38:32:41:35:6e:53:12:af:57:88:39:68:
+//	            81:e0:1b:4c:82:4a:de:ac:52:d4:46:a7:a2:55:73:
+//	            78:7a:fd:98:0f:bb:88:5b:bc:f6:7b:9a:77:49:11:
+//	            ec:e6:1b:f3:c3:76:4a
+//	        ASN1 OID: secp384r1
+//	        NIST CURVE: P-384
+//	X509v3 extensions:
+//	    X509v3 Key Usage: critical
+//	        Digital Signature, Key Encipherment
+//	    X509v3 Extended Key Usage:
+//	        TLS Web Server Authentication
+//	    X509v3 Basic Constraints: critical
+//	        CA:FALSE
+//	    X509v3 Authority Key Identifier:
+//	        1F:FE:3D:85:AC:F5:38:C7:90:1C:6C:EA:E7:5F:45:74:83:CC:95:39
+//	    X509v3 Subject Alternative Name:
+//	        DNS:test.transparency.dev
+//	    CT Precertificate Poison: critical
+//	        NULL
+//
+// Signature Algorithm: ecdsa-with-SHA384
+// Signature Value:
+//
+//	30:66:02:31:00:af:dc:05:cf:bc:09:c1:d1:a4:26:3f:29:87:
+//	87:ba:c9:e9:4c:d3:a6:06:c3:7c:64:0f:11:fe:d2:02:5c:50:
+//	3c:bf:5a:9f:b7:8f:d9:df:44:0e:15:08:27:90:b3:8c:57:02:
+//	31:00:ea:02:f2:78:e5:99:2d:9a:26:af:c5:49:da:42:9f:71:
+//	63:12:db:6d:85:55:43:d2:26:66:fd:5d:81:71:13:50:2d:69:
+//	cf:76:d7:05:3e:d6:04:3c:39:e7:20:7a:21:c2
+//
+//go:embed test_leaf_pre_cert_signed_by_pre_intermediate.pem
+var PreCertFromPreIntermediate string
+
+// Issuance chain 3
+// ================
+// The next section holds a self signed root, an intermediate, and a leaf cert.
+//
 // FakeCACertPEM is a test CA cert for testing.
 //
 //	Data:
@@ -463,7 +574,7 @@ D0XUxs5PIdZZGInfeqymk5feReWHBuPHpPIUObKxmQt+hcw6YsHE+0B84Xtx9BMe
 INV6z0j7hKQ6MPpE
 -----END CERTIFICATE-----`
 
-// Issuance chain 3
+// Issuance chain 4
 // ================
 // The next section holds a self signed root, intermediate certs
 // with various policy constraints, and a leaf cert.
@@ -753,7 +864,7 @@ Brd3sq2ogxuDOGReOiVR6VcfAFNy2wgRZT30AiEAoU5dtZqLEG4Voyq92YCRlnwa
 T4+R3ESfE/9X8F7OMjQ=
 -----END CERTIFICATE-----`
 
-// Issuance chain 4
+// Issuance chain 5
 // ================
 // The next section holds a real world intermediate and leaf cert.
 


### PR DESCRIPTION
Towards #120.

Gets rid of SHA1.