### PR TITLE
bump go to 1.24 and golangci-lint to 1.64.2

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,5 +19,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
-          version: v1.61.0
+          version: v1.64.2
           args: --timeout=5m

--- a/cmd/gcp/Dockerfile
+++ b/cmd/gcp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine3.19@sha256:ac67716dd016429be8d4c2c53a248d7bcdf06d34127d3dc451bda6aa5a87bc06 AS builder
+FROM golang:1.24.0-alpine3.21@sha256:2d40d4fc278dad38be0777d5e2a88a2c6dee51b0b29c97a764fc6c6a11ca893c AS builder
 
 ARG GOFLAGS="-trimpath -buildvcs=false -buildmode=exe"
 ENV GOFLAGS=$GOFLAGS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/static-ct
 
-go 1.23.1
+go 1.24.0
 
 require (
 	cloud.google.com/go/secretmanager v1.14.5

--- a/internal/hammer/Dockerfile
+++ b/internal/hammer/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM golang:1.23.0-alpine3.19@sha256:fe8f9c7d418d3ac91787f11c31071c4814b6da5f9aae55bc581a7aacc264c395 AS builder
+FROM golang:1.24.0-alpine3.21@sha256:2d40d4fc278dad38be0777d5e2a88a2c6dee51b0b29c97a764fc6c6a11ca893c AS builder
 
 ARG GOFLAGS="-trimpath -buildvcs=false -buildmode=exe"
 ENV GOFLAGS=$GOFLAGS


### PR DESCRIPTION
Towards #120 

This will allow to fork "crypto/x509" at its current version.

Verified that the following commands work:
  * `docker build -f ./internal/hammer/Dockerfile .`
  * `docker build -f ./cmd/gcp/Dockerfile .`