### PR TITLE
Bump tessera to ecabef06b8a186a552380a04f9ed4855e546af02

### DIFF
--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -187,7 +187,11 @@ func newGCPStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage,
 		return nil, fmt.Errorf("Failed to initialize GCP Tessera storage driver: %v", err)
 	}
 
-	appender, _, err := tessera.NewAppender(ctx, driver, tessera.WithCheckpointSigner(signer), tessera.WithCTLayout())
+	opts := tessera.NewAppendOptions().
+		WithCheckpointSigner(signer).
+		WithCTLayout()
+
+	appender, _, err := tessera.NewAppender(ctx, driver, opts)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to initialize GCP Tessera appender: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/rivo/tview v0.0.0-20240625185742-b0a7293b8130
 	github.com/transparency-dev/formats v0.0.0-20250127084410-134797944be6
 	github.com/transparency-dev/merkle v0.0.2
-	github.com/transparency-dev/trillian-tessera v0.1.1-0.20250213171719-5f7ca097f44a
+	github.com/transparency-dev/trillian-tessera v0.1.1-0.20250311134629-ecabef06b8a1
 	go.etcd.io/bbolt v1.4.0
 	golang.org/x/crypto v0.36.0
 	golang.org/x/mod v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -987,8 +987,8 @@ github.com/transparency-dev/formats v0.0.0-20250127084410-134797944be6 h1:TVUG0R
 github.com/transparency-dev/formats v0.0.0-20250127084410-134797944be6/go.mod h1:tSjZBSQ1ZMxgaOMppnyw48SbTDL947PD/8KYbvrx+lE=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/transparency-dev/trillian-tessera v0.1.1-0.20250213171719-5f7ca097f44a h1:b3ffGBgU7ZTcsvQrHAbLTBzDStL91/8pys69jIbrcMU=
-github.com/transparency-dev/trillian-tessera v0.1.1-0.20250213171719-5f7ca097f44a/go.mod h1:pkPCyRNzIkb+rsgsjZm8JCY8q7esZsgJzNK3jT1q/Cs=
+github.com/transparency-dev/trillian-tessera v0.1.1-0.20250311134629-ecabef06b8a1 h1:BS5jBBOMaaLJAR7Nmyjva4M3W2txzgGBw1DyCm1CqcM=
+github.com/transparency-dev/trillian-tessera v0.1.1-0.20250311134629-ecabef06b8a1/go.mod h1:uvyZ7WGpaRDPY+4Lme+s1vEUOluYevTYzrDg9j05cYU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This PR updates the `tessera` dep to `ecabef06b8a186a552380a04f9ed4855e546af02`, and tracks the changes introduced to the Tessera API.