### PR TITLE
Modernize for loop using `range` over `int`

### DIFF
--- a/internal/hammer/loadtest/analysis_test.go
+++ b/internal/hammer/loadtest/analysis_test.go
@@ -33,7 +33,7 @@ func TestHammerAnalyser_Stats(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	baseTime := time.Now().Add(-1 * time.Minute)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		ha.SeqLeafChan <- LeafTime{
 			Index:      uint64(i),
 			QueuedAt:   baseTime,


### PR DESCRIPTION
I missed this one in https://github.com/transparency-dev/static-ct/pull/172.