### PR TITLE
Add a bare-bones migrate tool for static-ct compliant logs

### DIFF
--- a/cmd/experimental/migrate/gcp/main.go
+++ b/cmd/experimental/migrate/gcp/main.go
@@ -1,0 +1,150 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// migrate-gcp is a command-line tool for migrating data from a static-ct
+// compliant log, into a TesseraCT log instance.
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	tessera "github.com/transparency-dev/trillian-tessera"
+	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/client"
+	"github.com/transparency-dev/trillian-tessera/storage/gcp"
+	gcp_as "github.com/transparency-dev/trillian-tessera/storage/gcp/antispam"
+	"k8s.io/klog/v2"
+)
+
+var (
+	bucket  = flag.String("bucket", "", "Bucket to use for storing log")
+	spanner = flag.String("spanner", "", "Spanner resource URI ('projects/.../...')")
+
+	sourceURL          = flag.String("source_url", "", "Base URL for the source log.")
+	numWorkers         = flag.Int("num_workers", 30, "Number of migration worker goroutines.")
+	persistentAntispam = flag.Bool("antispam", false, "EXPERIMENTAL: Set to true to enable GCP-based persistent antispam storage")
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+	ctx := context.Background()
+
+	srcURL, err := url.Parse(*sourceURL)
+	if err != nil {
+		klog.Exitf("Invalid --source_url %q: %v", *sourceURL, err)
+	}
+	// TODO(phbnf): This is currently built using the Tessera client lib, with a stand-alone func below for
+	// fetching the Static CT entry bundles as they live in an different place.
+	// When there's a Static CT client we can probably switch over to using it in here.
+	src, err := client.NewHTTPFetcher(srcURL, nil)
+	if err != nil {
+		klog.Exitf("Failed to create HTTP fetcher: %v", err)
+	}
+	sourceCP, err := src.ReadCheckpoint(ctx)
+	if err != nil {
+		klog.Exitf("fetch initial source checkpoint: %v", err)
+	}
+	// TODO(AlCutter): We should be properly verifying and opening the checkpoint here with the source log's
+	// public key.
+	bits := strings.Split(string(sourceCP), "\n")
+	sourceSize, err := strconv.ParseUint(bits[1], 10, 64)
+	if err != nil {
+		klog.Exitf("invalid CP size %q: %v", bits[1], err)
+	}
+	sourceRoot, err := base64.StdEncoding.DecodeString(bits[2])
+	if err != nil {
+		klog.Exitf("invalid checkpoint roothash %q: %v", bits[2], err)
+	}
+
+	// Create our Tessera storage backend:
+	gcpCfg := storageConfigFromFlags()
+	driver, err := gcp.New(ctx, gcpCfg)
+	if err != nil {
+		klog.Exitf("Failed to create new GCP storage driver: %v", err)
+	}
+
+	opts := tessera.NewMigrationOptions().WithCTLayout()
+	// Configure antispam storage, if necessary
+	var antispam tessera.Antispam
+	// Persistent antispam is currently experimental, so there's no terraform or documentation yet!
+	if *persistentAntispam {
+		antispam, err = gcp_as.NewAntispam(ctx, fmt.Sprintf("%s-antispam", *spanner))
+		if err != nil {
+			klog.Exitf("Failed to create new GCP antispam storage: %v", err)
+		}
+		opts.WithAntispam(antispam)
+	}
+
+	m, err := tessera.NewMigrationTarget(ctx, driver, opts)
+	if err != nil {
+		klog.Exitf("Failed to create MigrationTarget: %v", err)
+	}
+
+	readEntryBundle := readCTEntryBundle(*sourceURL)
+	if err := tessera.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, readEntryBundle, m); err != nil {
+		klog.Exitf("Migrate failed: %v", err)
+	}
+
+	// TODO(phbnf): This will need extending to identify and copy over the entries from the intermediate cert storage.
+
+	// TODO(Tessera #341): wait for antispam follower to complete
+	<-make(chan bool)
+}
+
+// storageConfigFromFlags returns a gcp.Config struct populated with values
+// provided via flags.
+func storageConfigFromFlags() gcp.Config {
+	if *bucket == "" {
+		klog.Exit("--bucket must be set")
+	}
+	if *spanner == "" {
+		klog.Exit("--spanner must be set")
+	}
+	return gcp.Config{
+		Bucket:  *bucket,
+		Spanner: *spanner,
+	}
+}
+
+func readCTEntryBundle(srcURL string) func(ctx context.Context, i uint64, p uint8) ([]byte, error) {
+	return func(ctx context.Context, i uint64, p uint8) ([]byte, error) {
+		up := strings.Replace(layout.EntriesPath(i, p), "entries", "data", 1)
+		reqURL, err := url.JoinPath(srcURL, up)
+		if err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		rsp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer rsp.Body.Close()
+		if rsp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GET %q: %v", req.URL.Path, rsp.Status)
+		}
+		return io.ReadAll(rsp.Body)
+	}
+}

--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -178,7 +178,7 @@ func newGCPStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage,
 		WithCheckpointSigner(signer).
 		WithCTLayout()
 
-	// TODO(phboneff): figure out the best way to thread the `shutdown` func NewAppends returns back out to main so we can cleanly close Tessera down
+	// TODO(phbnf): figure out the best way to thread the `shutdown` func NewAppends returns back out to main so we can cleanly close Tessera down
 	// when it's time to exit.
 	appender, _, _, err := tessera.NewAppender(ctx, driver, opts)
 	if err != nil {

--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -178,7 +178,9 @@ func newGCPStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage,
 		WithCheckpointSigner(signer).
 		WithCTLayout()
 
-	appender, _, err := tessera.NewAppender(ctx, driver, opts)
+	// TODO(phboneff): figure out the best way to thread the `shutdown` func NewAppends returns back out to main so we can cleanly close Tessera down
+	// when it's time to exit.
+	appender, _, _, err := tessera.NewAppender(ctx, driver, opts)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to initialize GCP Tessera appender: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rivo/tview v0.0.0-20240625185742-b0a7293b8130
 	github.com/transparency-dev/formats v0.0.0-20250127084410-134797944be6
 	github.com/transparency-dev/merkle v0.0.2
-	github.com/transparency-dev/trillian-tessera v0.1.1-0.20250311134629-ecabef06b8a1
+	github.com/transparency-dev/trillian-tessera v0.1.1-0.20250314143707-b7c8fb6d4491
 	go.etcd.io/bbolt v1.4.0
 	golang.org/x/crypto v0.36.0
 	golang.org/x/mod v0.24.0
@@ -40,6 +40,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.49.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.49.0 // indirect
+	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20241223141626-cff3c89139a3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -646,6 +646,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
+github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
+github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -974,8 +976,8 @@ github.com/transparency-dev/formats v0.0.0-20250127084410-134797944be6 h1:TVUG0R
 github.com/transparency-dev/formats v0.0.0-20250127084410-134797944be6/go.mod h1:tSjZBSQ1ZMxgaOMppnyw48SbTDL947PD/8KYbvrx+lE=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/transparency-dev/trillian-tessera v0.1.1-0.20250311134629-ecabef06b8a1 h1:BS5jBBOMaaLJAR7Nmyjva4M3W2txzgGBw1DyCm1CqcM=
-github.com/transparency-dev/trillian-tessera v0.1.1-0.20250311134629-ecabef06b8a1/go.mod h1:uvyZ7WGpaRDPY+4Lme+s1vEUOluYevTYzrDg9j05cYU=
+github.com/transparency-dev/trillian-tessera v0.1.1-0.20250314143707-b7c8fb6d4491 h1:HZg3ZJqnMJ2X+t+2jMP2GY1vXrES6R1YtADIURAxb0o=
+github.com/transparency-dev/trillian-tessera v0.1.1-0.20250314143707-b7c8fb6d4491/go.mod h1:uvyZ7WGpaRDPY+4Lme+s1vEUOluYevTYzrDg9j05cYU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This PR uses the Tessera `migration` lifecycle mode and helper library to implement a very simple Static CT migration tool.

More work will be required to make it complete, e.g. copy over intermediates, etc., but this should serve as a simple _"starter for 10"_.

```
$ go run ./cmd/experimental/migrate/gcp/ct --bucket=... --spanner=... --logtostderr --antispam=true --source_url=https://rome2025h2.fly.storage.tigris.dev --num_workers=100
I0314 14:26:18.891263  130074 migrate.go:86] Starting migration; source size 15847357 root a2323986bfd4092cb7e21345df470773ddba397da74b35902b2874bfc55cebd6
I0314 14:26:18.895792  130074 migrate.go:158] Spans for entry range [0, 15847357)
I0314 14:26:19.900699  130074 migrate.go:122] integration: 0 (0.00%)  bundles: 3 (0.00%)
I0314 14:26:19.919323  130074 gcp.go:1090] Integrate from 0 (Target 15847357)

...

I0314 14:35:10.456128  130187 gcp.go:628] New tree: 15847357, a2323986bfd4092cb7e21345df470773ddba397da74b35902b2874bfc55cebd6                                                                                                                                                 │  73373 root        20   0 1213M 24100 12900 S   0.0  0.1  0:00.00 /usr/bin/google_guest_agent
I0314 14:35:10.456148  130187 gcp.go:1191] Integrate: added 26557 entries                                                                                                                                                                                                      │  73432 root        20   0 31324 14312 12392 S   0.0  0.0  0:00.35 /lib/systemd/systemd-logind
I0314 14:35:10.462239  130187 gcp.go:1096] Integrated to 15847357 with roothash a2323986bfd4092cb7e21345df470773ddba397da74b35902b2874bfc55cebd6                                                                                                                               │  73443 root        20   0 1213M 24540 14296 S   0.0  0.1  3:46.82 /usr/bin/google_guest_agent_manager
I0314 14:35:10.462265  130187 migrate.go:151] Migration successful.
```