### PR TITLE
Run a monitoring sidecar to collect metrics

### DIFF
--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -70,6 +70,11 @@ resource "google_cloud_run_v2_service" "default" {
         }
       }
     }
+    containers {
+      image      = "us-docker.pkg.dev/cloud-ops-agents-artifacts/cloud-run-gmp-sidecar/cloud-run-gmp-sidecar:1.2.0"
+      name       = "collector"
+      depends_on = ["conformance"]
+    }
   }
 
   deletion_protection = false

--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -41,6 +41,7 @@ resource "google_cloud_run_v2_service" "default" {
         "--logtostderr",
         "--v=1",
         "--http_endpoint=:6962",
+        "--metrics_endpoint=:8080",
         "--bucket=${var.bucket}",
         "--spanner_db_path=${local.spanner_log_db_path}",
         "--spanner_dedup_db_path=${local.spanner_dedup_db_path}",


### PR DESCRIPTION
Towards #105 and #104.

We don't *need* such a feature for the ci environment, but we'll need it for the staging one, so we might as well replicate the same setup in the ci environment.