### PR TITLE
Change metric naming, unit, and http fields

### DIFF
--- a/internal/scti/handlers.go
+++ b/internal/scti/handlers.go
@@ -97,19 +97,19 @@ func setupMetrics() {
 			Name: "ct_http_requests_total",
 			Help: "Number of requests",
 		},
-		[]string{"origin", "ep"})
+		[]string{"origin", "operation"})
 	rspsCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ct_http_responses_total",
 			Help: "Number of responses",
 		},
-		[]string{"origin", "op", "code"})
+		[]string{"origin", "operation", "code"})
 	rspDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "ct_http_request_duration_seconds",
 			Help: "Latency of responses in seconds",
 		},
-		[]string{"origin", "op", "code"})
+		[]string{"origin", "operation", "code"})
 }
 
 // entrypoints is a list of entrypoint names as exposed in statistics/logging.

--- a/internal/scti/handlers.go
+++ b/internal/scti/handlers.go
@@ -76,37 +76,37 @@ func setupMetrics() {
 	// TODO(phboneff): add metrics for deduplication and chain storage.
 	knownLogs = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "known_logs",
+			Name: "ct_known_logs",
 			Help: "Set to 1 for known logs",
 		},
 		[]string{"origin"})
 	lastSCTTimestamp = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "last_sct_timestamp",
+			Name: "ct_last_sct_timestamp_ms",
 			Help: "Time of last SCT in ms since epoch",
 		},
 		[]string{"origin"})
 	lastSCTIndex = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "last_sct_index",
+			Name: "ct_last_sct_index",
 			Help: "Index of last SCT",
 		},
 		[]string{"origin"})
 	reqsCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "http_reqs",
+			Name: "ct_http_reqs",
 			Help: "Number of requests",
 		},
 		[]string{"origin", "ep"})
 	rspsCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "http_rsps",
+			Name: "ct_http_rsps",
 			Help: "Number of responses",
 		},
 		[]string{"origin", "op", "code"})
 	rspLatency = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "http_latency",
+			Name: "ct_http_latency",
 			Help: "Latency of responses in seconds",
 		},
 		[]string{"origin", "op", "code"})


### PR DESCRIPTION
Towards #105.

Following recommendations from: https://prometheus.io/docs/practices/naming/

Prefix all the metrics with `ct_`, and suffix with units. Also, use seconds for the SCT timestamp unit since this is what guidelines recommend.... even if an SCT timestamp is in milliseconds... I'm a bit on the fence for this one, but these metrics are meant for graphs and human consumption, so seconds seem to more adapted indeed (and for anything more fancy, milliseconds are still available since the number exported is a float).

Note that I'm explicitly specifying the `ct_` prefix manually and not using a wrapper, not to break code searching: I find that searching for a metric name is very useful when investigating an outage.