### PR TITLE
Print terragrunt output to console in GCP Cloud Build preloader trigger

### DIFF
--- a/deployment/modules/gcp/cloudbuild/preloaded/main.tf
+++ b/deployment/modules/gcp/cloudbuild/preloaded/main.tf
@@ -109,10 +109,10 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       name   = "alpine/terragrunt"
       script = <<EOT
         terragrunt --terragrunt-non-interactive --terragrunt-no-color apply -auto-approve -no-color 2>&1
-        terragrunt --terragrunt-no-color output --raw conformance_url -no-color > /workspace/output
+        terragrunt --terragrunt-no-color output --raw conformance_url -no-color > /workspace/conformance_url
         terragrunt --terragrunt-no-color output --raw conformance_bucket_name -no-color > /workspace/conformance_bucket_name
         terragrunt --terragrunt-no-color output --raw ecdsa_p256_public_key_data -no-color > /workspace/conformance_log_public_key.pem
-        cat /workspace/output
+        cat /workspace/conformance_url
         cat /workspace/conformance_bucket_name
         cat /workspace/conformance_log_public_key.pem
       EOT


### PR DESCRIPTION
Removing these 3 lines as they don't seem to be used anywhere.