### PR TITLE
Print Terraform output in separate step

### DIFF
--- a/deployment/modules/gcp/cloudbuild/conformance/main.tf
+++ b/deployment/modules/gcp/cloudbuild/conformance/main.tf
@@ -135,7 +135,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       wait_for = ["preclean_env", "docker_push_conformance_gcp"]
     }
 
-    ## Print Terragrunt output.
+    ## Print Terragrunt output to files.
     step {
       id     = "terraform_print_output"
       name   = "alpine/terragrunt"


### PR DESCRIPTION
This will ensure that if `terraform apply` fails, the cloudbuild step will also fail.

We need to do the same thing for arch2025h1, it will come in a few PR, it's somewhere in my stack, but would be tricky to rebase since I'm also renaming a few files.