### PR TITLE
Remove `metrics_endpoint` flag in GCP CI pipeline

### DIFF
--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -41,7 +41,6 @@ resource "google_cloud_run_v2_service" "default" {
         "--logtostderr",
         "--v=1",
         "--http_endpoint=:6962",
-        "--metrics_endpoint=:8080",
         "--bucket=${var.bucket}",
         "--spanner_db_path=${local.spanner_log_db_path}",
         "--spanner_dedup_db_path=${local.spanner_dedup_db_path}",


### PR DESCRIPTION
The GCP CI pipeline is now broken since the `metrics_endpoint` flag was already removed in https://github.com/transparency-dev/static-ct/pull/242.