### PR TITLE
remove metric endpoint and sidecar

### DIFF
--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -41,7 +41,6 @@ resource "google_cloud_run_v2_service" "default" {
         "--logtostderr",
         "--v=1",
         "--http_endpoint=:6962",
-        "--metrics_endpoint=:8080",
         "--bucket=${var.bucket}",
         "--spanner_db_path=${local.spanner_log_db_path}",
         "--spanner_dedup_db_path=${local.spanner_dedup_db_path}",
@@ -70,11 +69,6 @@ resource "google_cloud_run_v2_service" "default" {
           port = 6962
         }
       }
-    }
-    containers {
-      image      = "us-docker.pkg.dev/cloud-ops-agents-artifacts/cloud-run-gmp-sidecar/cloud-run-gmp-sidecar:1.2.0"
-      name       = "collector"
-      depends_on = ["conformance"]
     }
   }
 


### PR DESCRIPTION
Towards https://github.com/transparency-dev/static-ct/issues/105 and https://github.com/transparency-dev/static-ct/issues/104.

We're shifting from prometheus to open telemetry.