### PR TITLE
Limit the AWS conformance CI workflow to `transparency-dev/static-ct` repo

### DIFF
--- a/.github/workflows/aws_conformance_ci.yml
+++ b/.github/workflows/aws_conformance_ci.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   aws-conformance-ci:
+    if: github.repository == 'transparency-dev/static-ct'
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
This workflow runs on the fork repos and will fail with the following error.

```
Error: Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```

After this change is merged, the AWS Conformance CI workflow will skip if the repo is not `transparency-dev/static-ct`.

See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository.