### PR TITLE
Reshape resources

### DIFF
--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
@@ -8,6 +8,7 @@ locals {
   base_name           = include.root.locals.base_name
   origin_suffix       = include.root.locals.origin_suffix
   server_docker_image = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/conformance-gcp:${include.root.locals.docker_container_tag}"
+  spanner_pu          = 500
 }
 
 include "root" {

--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -32,6 +32,7 @@ resource "google_cloud_run_v2_service" "default" {
 
     scaling {
       max_instance_count = 3
+      min_instance_count = 1
     }
 
     containers {
@@ -55,8 +56,8 @@ resource "google_cloud_run_v2_service" "default" {
 
       resources {
         limits = {
-          cpu    = "2000m"
-          memory = "1Gi"
+          cpu    = "4000m"
+          memory = "2Gi"
         }
       }
 

--- a/deployment/modules/gcp/storage/main.tf
+++ b/deployment/modules/gcp/storage/main.tf
@@ -45,7 +45,7 @@ resource "google_spanner_instance" "log_spanner" {
   name                         = var.base_name
   config                       = "regional-${var.location}"
   display_name                 = var.base_name
-  processing_units             = 100
+  processing_units             = var.spanner_pu
   default_backup_schedule_type = "NONE"
 
   force_destroy = var.ephemeral

--- a/deployment/modules/gcp/storage/variables.tf
+++ b/deployment/modules/gcp/storage/variables.tf
@@ -17,3 +17,9 @@ variable "ephemeral" {
   description = "Set to true if this is a throwaway/temporary log instance. Will set attributes on created resources to allow them to be disabled/deleted more easily."
   type = bool
 }
+
+variable "spanner_pu" {
+  description = "Amount of Spanner processing units"
+  type = number
+  default = 100
+}

--- a/deployment/modules/gcp/tesseract/conformance/main.tf
+++ b/deployment/modules/gcp/tesseract/conformance/main.tf
@@ -9,6 +9,7 @@ module "storage" {
   base_name  = var.base_name
   location   = var.location
   ephemeral  = var.ephemeral
+  spanner_pu = var.spanner_pu
 }
 
 module "secretmanager" {

--- a/deployment/modules/gcp/tesseract/conformance/variables.tf
+++ b/deployment/modules/gcp/tesseract/conformance/variables.tf
@@ -33,6 +33,12 @@ variable "server_docker_image" {
   type        = string
 }
 
+variable "spanner_pu" {
+  description = "Amount of Spanner processing units"
+  type = number
+  default = 100
+}
+
 variable "ephemeral" {
   description = "Set to true if this is a throwaway/temporary log instance. Will set attributes on created resources to allow them to be disabled/deleted more easily."
   default     = false


### PR DESCRIPTION
Towards #104.

This PR make the number of PUs configurable, and increases it for arche2025h1.
It also:
 - makes sure there's always at least one cloudrun instance running
 - doubles cloudrun usages across all instances (ci and staging), we'll make these settings configurable if need be later.