### PR TITLE
Bump golangci-lint from 2.0.2 to 2.1.6

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,5 +19,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v2.0.2
+          version: v2.1.6
           args: --timeout=5m


### PR DESCRIPTION
Unblock https://github.com/transparency-dev/static-ct/pull/285.