### PR TITLE
Set `ephemeral` to `true` in GCP test terraform config

### DIFF
--- a/deployment/modules/gcp/tesseract/test/main.tf
+++ b/deployment/modules/gcp/tesseract/test/main.tf
@@ -8,7 +8,7 @@ module "storage" {
   project_id = var.project_id
   base_name  = var.base_name
   location   = var.location
-  ephemeral  = false
+  ephemeral  = true
 }
 
 module "secretmanager" {


### PR DESCRIPTION
This allows the test instance to be disabled/deleted more easily.