### PR TITLE
Rename as many things as possible to TesseraCT in terraform

### DIFF
--- a/cmd/aws/main.go
+++ b/cmd/aws/main.go
@@ -64,7 +64,7 @@ var (
 	inMemoryAntispamCacheSize  = flag.Uint("inmemory_antispam_cache_size", 256<<10, "Maximum number of entries to keep in the in-memory antispam cache.")
 	rootsPemFile               = flag.String("roots_pem_file", "", "Path to the file containing root certificates that are acceptable to the log. The certs are served through get-roots endpoint.")
 	rejectExpired              = flag.Bool("reject_expired", false, "If true then the certificate validity period will be checked against the current time during the validation of submissions. This will cause expired certificates to be rejected.")
-	rejectUnexpired            = flag.Bool("reject_unexpired", false, "If true then CTFE rejects certificates that are either currently valid or not yet valid.")
+	rejectUnexpired            = flag.Bool("reject_unexpired", false, "If true then TesseraCT rejects certificates that are either currently valid or not yet valid.")
 	extKeyUsages               = flag.String("ext_key_usages", "", "If set, will restrict the set of such usages that the server will accept. By default all are accepted. The values specified must be ones known to the x509 package.")
 	rejectExtensions           = flag.String("reject_extension", "", "A list of X.509 extension OIDs, in dotted string form (e.g. '2.3.4.5') which, if present, should cause submissions to be rejected.")
 	signerPublicKeySecretName  = flag.String("signer_public_key_secret_name", "", "Public key secret name for checkpoints and SCTs signer")

--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -58,7 +58,7 @@ var (
 	inMemoryAntispamCacheSize  = flag.Uint("inmemory_antispam_cache_size", 256<<10, "Maximum number of entries to keep in the in-memory antispam cache.")
 	rootsPemFile               = flag.String("roots_pem_file", "", "Path to the file containing root certificates that are acceptable to the log. The certs are served through get-roots endpoint.")
 	rejectExpired              = flag.Bool("reject_expired", false, "If true then the certificate validity period will be checked against the current time during the validation of submissions. This will cause expired certificates to be rejected.")
-	rejectUnexpired            = flag.Bool("reject_unexpired", false, "If true then CTFE rejects certificates that are either currently valid or not yet valid.")
+	rejectUnexpired            = flag.Bool("reject_unexpired", false, "If true then TesseraCT rejects certificates that are either currently valid or not yet valid.")
 	extKeyUsages               = flag.String("ext_key_usages", "", "If set, will restrict the set of such usages that the server will accept. By default all are accepted. The values specified must be ones known to the x509 package.")
 	rejectExtensions           = flag.String("reject_extension", "", "A list of X.509 extension OIDs, in dotted string form (e.g. '2.3.4.5') which, if present, should cause submissions to be rejected.")
 	signerPublicKeySecretName  = flag.String("signer_public_key_secret_name", "", "Public key secret name for checkpoints and SCTs signer. Format: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}.")

--- a/deployment/live/aws/test/README.md
+++ b/deployment/live/aws/test/README.md
@@ -82,11 +82,11 @@ export SCTFE_SIGNER_ECDSA_P256_PRIVATE_KEY_ID=$(terragrunt output -raw ecdsa_p25
 
 Connect the VM and Aurora database following [these instructions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/tutorial-ec2-rds-option1.html#option1-task3-connect-ec2-instance-to-rds-database), it takes a few clicks in the UI.
 
-## Run the TesseraCT
+## Run TesseraCT
 
 ### With fake chains
 
-On the VM, run the following command to bring up the TesseraCT:
+On the VM, run the following command to bring up TesseraCT:
 
 ```bash
 go run ./cmd/aws \
@@ -121,7 +121,7 @@ openssl x509 -req -days 3650 -in /tmp/httpschain/cert.csr -CAkey internal/testda
 cat internal/testdata/fake-ca.cert >> /tmp/httpschain/chain.pem
 ```
 
-Finally, submit the chain to the TesseraCT:
+Finally, submit the chain to TesseraCT:
 
 ```bash
 go run github.com/google/certificate-transparency-go/client/ctclient@master upload --cert_chain=/tmp/httpschain/chain.pem --skip_https_verify --log_uri=http://localhost:6962/test-static-ct
@@ -129,7 +129,7 @@ go run github.com/google/certificate-transparency-go/client/ctclient@master uplo
 
 #### Automatically generate chains
 
-Save the TesseraCT repo's path:
+Save TesseraCT repo's path:
 
 ```bash
 export TESSERACT_REPO=$(pwd)
@@ -179,7 +179,7 @@ go run ./client/ctclient get-roots --log_uri=${SRC_LOG_URI} --text=false > /tmp/
 sed -i 's-""-"/tmp/hammercfg/roots.pem"-g' /tmp/hammercfg/hammer.cfg
 ```
 
-Run the TesseraCT with the same roots:
+Run TesseraCT with the same roots:
 
 ```bash
 cd ${TESSERACT_REPO}

--- a/deployment/live/aws/test/README.md
+++ b/deployment/live/aws/test/README.md
@@ -76,8 +76,8 @@ Store the Aurora RDS database and S3 bucket information into the environment var
 export TESSERACT_DB_HOST=$(terragrunt output -raw rds_aurora_cluster_endpoint)
 export TESSERACT_DB_PASSWORD=$(aws secretsmanager get-secret-value --secret-id $(terragrunt output -json rds_aurora_cluster_master_user_secret | jq --raw-output .[0].secret_arn) --query SecretString --output text | jq --raw-output .password)
 export TESSERACT_BUCKET_NAME=$(terragrunt output -raw s3_bucket_name)
-export SCTFE_SIGNER_ECDSA_P256_PUBLIC_KEY_ID=$(terragrunt output -raw ecdsa_p256_public_key_id)
-export SCTFE_SIGNER_ECDSA_P256_PRIVATE_KEY_ID=$(terragrunt output -raw ecdsa_p256_private_key_id)
+export TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID=$(terragrunt output -raw ecdsa_p256_public_key_id)
+export TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID=$(terragrunt output -raw ecdsa_p256_private_key_id)
 ```
 
 Connect the VM and Aurora database following [these instructions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/tutorial-ec2-rds-option1.html#option1-task3-connect-ec2-instance-to-rds-database), it takes a few clicks in the UI.
@@ -100,8 +100,8 @@ go run ./cmd/aws \
   --db_user=tesseract \
   --db_password=${TESSERACT_DB_PASSWORD} \
   --antispam_db_name=antispam_db \
-  --signer_public_key_secret_name=${SCTFE_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
-  --signer_private_key_secret_name=${SCTFE_SIGNER_ECDSA_P256_PRIVATE_KEY_ID}
+  --signer_public_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
+  --signer_private_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID}
 ```
 
 In a different terminal you can either mint and submit certificates manually, or
@@ -194,8 +194,8 @@ go run ./cmd/aws \
   --db_user=tesseract \
   --db_password=${TESSERACT_DB_PASSWORD} \
   --antispam_db_name=antispam_db \
-  --signer_public_key_secret_name=${SCTFE_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
-  --signer_private_key_secret_name=${SCTFE_SIGNER_ECDSA_P256_PRIVATE_KEY_ID}
+  --signer_public_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
+  --signer_private_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID}
   -v=3
 ```
 

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h1/README.md
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h1/README.md
@@ -25,7 +25,7 @@ awk \
 
 
 ### Automatic Deployment
-This GCP SCTFE preloaded staging environment is designed to be deployed by the Cloud Build ([Terraform module](/deployment/modules/gcp/cloudbuild/tesseract/), [Terragrunt configuration](/deployment/live/gcp/static-ct-staging/cloudbuild/arche2025h1/)).
+This GCP TesseraCT preloaded staging environment is designed to be deployed by the Cloud Build ([Terraform module](/deployment/modules/gcp/cloudbuild/tesseract/), [Terragrunt configuration](/deployment/live/gcp/static-ct-staging/cloudbuild/arche2025h1/)).
 
 ### Manual Deployment
 TODO(phboneff): come back to this, Cloud Run doesn't trigger a deployment if the tag does not change value.

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h1/README.md
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h1/README.md
@@ -51,10 +51,10 @@ Build and push the Docker image to Artifact Registry repository:
 
 ```sh
 gcloud auth configure-docker ${GOOGLE_REGION}-docker.pkg.dev
-docker build -f ./cmd/gcp/Dockerfile -t tesseract-gcp:latest .
-docker build -f ./cmd/gcp/staging/Dockerfile -t conformance-gcp:latest .
-docker tag conformance-gcp:latest ${GOOGLE_REGION}-docker.pkg.dev/${GOOGLE_PROJECT}/docker-staging/conformance-gcp:latest
-docker push ${GOOGLE_REGION}-docker.pkg.dev/${GOOGLE_PROJECT}/docker-staging/conformance-gcp
+docker build -f ./cmd/gcp/Dockerfile -t tesseract-binary-gcp:latest .
+docker build -f ./cmd/gcp/staging/Dockerfile -t tesseract-gcp:latest .
+docker tag tesseract-gcp:latest ${GOOGLE_REGION}-docker.pkg.dev/${GOOGLE_PROJECT}/docker-staging/tesseract-gcp:latest
+docker push ${GOOGLE_REGION}-docker.pkg.dev/${GOOGLE_PROJECT}/docker-staging/tesseract-gcp
 ```
 
 Terraforming the project can be done by:

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
@@ -7,7 +7,7 @@ locals {
   docker_env          = local.env
   base_name           = include.root.locals.base_name
   origin_suffix       = include.root.locals.origin_suffix
-  server_docker_image = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/conformance-gcp:${include.root.locals.docker_container_tag}"
+  server_docker_image = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
   spanner_pu          = 500
 }
 

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h2/README.md
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h2/README.md
@@ -25,7 +25,7 @@ awk \
 
 
 ### Automatic Deployment
-This GCP SCTFE preloaded staging environment is designed to be deployed by the Cloud Build ([Terraform module](/deployment/modules/gcp/cloudbuild/tesseract/), [Terragrunt configuration](/deployment/live/gcp/static-ct-staging/cloudbuild/arche2025h2/)).
+This GCP TesseraCT preloaded staging environment is designed to be deployed by the Cloud Build ([Terraform module](/deployment/modules/gcp/cloudbuild/tesseract/), [Terragrunt configuration](/deployment/live/gcp/static-ct-staging/cloudbuild/arche2025h2/)).
 
 ### Manual Deployment
 TODO(phboneff): come back to this, Cloud Run doesn't trigger a deployment if the tag does not change value.

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h2/README.md
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h2/README.md
@@ -51,10 +51,10 @@ Build and push the Docker image to Artifact Registry repository:
 
 ```sh
 gcloud auth configure-docker ${GOOGLE_REGION}-docker.pkg.dev
-docker build -f ./cmd/gcp/Dockerfile -t tesseract-gcp:latest .
-docker build -f ./cmd/gcp/staging/Dockerfile -t conformance-gcp:latest .
-docker tag conformance-gcp:latest ${GOOGLE_REGION}-docker.pkg.dev/${GOOGLE_PROJECT}/docker-staging/conformance-gcp:latest
-docker push ${GOOGLE_REGION}-docker.pkg.dev/${GOOGLE_PROJECT}/docker-staging/conformance-gcp
+docker build -f ./cmd/gcp/Dockerfile -t tesseract-binary-gcp:latest .
+docker build -f ./cmd/gcp/staging/Dockerfile -t tesseract-gcp:latest .
+docker tag tesseract-gcp:latest ${GOOGLE_REGION}-docker.pkg.dev/${GOOGLE_PROJECT}/docker-staging/tesseract-gcp:latest
+docker push ${GOOGLE_REGION}-docker.pkg.dev/${GOOGLE_PROJECT}/docker-staging/tesseract-gcp
 ```
 
 Terraforming the project can be done by:

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
@@ -7,7 +7,7 @@ locals {
   docker_env          = local.env
   base_name           = include.root.locals.base_name
   origin_suffix       = include.root.locals.origin_suffix
-  server_docker_image = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/conformance-gcp:${include.root.locals.docker_container_tag}"
+  server_docker_image = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
   spanner_pu          = 500
 }
 

--- a/deployment/live/gcp/static-ct/logs/ci/README.md
+++ b/deployment/live/gcp/static-ct/logs/ci/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This config uses the [gcp/cloudrun](/deployment/modules/gcp/tesseract/cloudrun) module to
-define a CI environment to run the SCTFE on Cloud Run, backed by Trillian Tessera.
+define a CI environment to run TesseraCT on Cloud Run, backed by Trillian Tessera.
 
 At a high level, this environment consists of:
 - One Spanner instance with two databases:

--- a/deployment/live/gcp/static-ct/logs/ci/README.md
+++ b/deployment/live/gcp/static-ct/logs/ci/README.md
@@ -1,4 +1,4 @@
-# GCP SCTFE CI Environment
+# GCP TesseraCT CI Environment
 
 ## Overview
 
@@ -15,7 +15,7 @@ At a high level, this environment consists of:
 
 ### Automatic Deployment
 
-This GCP SCTFE conformance CI environment is designed to be deployed by the Cloud Build ([Terraform module](/deployment/modules/gcp/cloudbuild/conformance/), [Terragrunt configuration](/deployment/live/gcp/static-ct/cloudbuild/prod/)).
+This GCP TesseraCT conformance CI environment is designed to be deployed by the Cloud Build ([Terraform module](/deployment/modules/gcp/cloudbuild/conformance/), [Terragrunt configuration](/deployment/live/gcp/static-ct/cloudbuild/prod/)).
 
 ### Manual Deployment
 

--- a/deployment/live/gcp/test/README.md
+++ b/deployment/live/gcp/test/README.md
@@ -1,4 +1,4 @@
-# GCP SCTFE Test Environment
+# GCP TesseraCT Test Environment
 
 ## Prerequisites
 You'll need to have a VM running in the same GCP project that you can SSH to,
@@ -42,8 +42,8 @@ Terraforming the project can be done by:
 Store the Secret Manager resource ID of signer key pair into the environment variables:
 
 ```sh
-export SCTFE_SIGNER_ECDSA_P256_PUBLIC_KEY_ID=$(terragrunt output -raw ecdsa_p256_public_key_id)
-export SCTFE_SIGNER_ECDSA_P256_PRIVATE_KEY_ID=$(terragrunt output -raw ecdsa_p256_private_key_id)
+export TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID=$(terragrunt output -raw ecdsa_p256_public_key_id)
+export TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID=$(terragrunt output -raw ecdsa_p256_private_key_id)
 ```
 
 ## Run TesseraCT
@@ -59,8 +59,8 @@ go run ./cmd/gcp/ \
   --spanner_antispam_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-antispam-db \
   --roots_pem_file=./internal/testdata/fake-ca.cert \
   --origin=${TESSERA_BASE_NAME} \
-  --signer_public_key_secret_name=${SCTFE_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
-  --signer_private_key_secret_name=${SCTFE_SIGNER_ECDSA_P256_PRIVATE_KEY_ID}
+  --signer_public_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
+  --signer_private_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID}
 ```
 
 In a different terminal you can either mint and submit certificates manually, or
@@ -91,7 +91,7 @@ go run github.com/google/certificate-transparency-go/client/ctclient@master uplo
 Save TesseraCT repo's path:
 
 ```bash
-export SCTFE_REPO=$(pwd)
+export TESSERACT_REPO=$(pwd)
 ```
 
 Clone the [certificate-transparency-go](https://github.com/google/certificate-transparency-go) repo, and from there run:
@@ -111,19 +111,19 @@ go run ./trillian/integration/ct_hammer/ \
   --skip_https_verify=true \
   --operations=10000 \
   --rate_limit=150 \
-  --log_config=${SCTFE_REPO}/internal/testdata/hammer.cfg \
+  --log_config=${TESSERACT_REPO}/internal/testdata/hammer.cfg \
   --testdata_dir=./trillian/testdata/
 ```
 
 ### With real HTTPS certificates
 
-We'll run a SCTFE and copy certificates from an existing RFC6962 log to it.
+We'll run a TESSERACT and copy certificates from an existing RFC6962 log to it.
 It uses the [ct_hammer tool from certificate-transparency-go](https://github.com/google/certificate-transparency-go/tree/aceb1d4481907b00c087020a3930c7bd691a0110/trillian/integration/ct_hammer).
 
 First, set a few environment variables:
 
 ```bash
-export SCTFE_REPO=$(pwd)
+export TESSERACT_REPO=$(pwd)
 export SRC_LOG_URI=https://ct.googleapis.com/logs/xenon2022
 ```
 
@@ -133,7 +133,7 @@ To do so, clone the [certificate-transparency-go](https://github.com/google/cert
 ```bash
 export CTGO_REPO=$(pwd)
 mkdir -p /tmp/hammercfg
-cp ${SCTFE_REPO}/internal/testdata/hammer.cfg /tmp/hammercfg
+cp ${TESSERACT_REPO}/internal/testdata/hammer.cfg /tmp/hammercfg
 go run ./client/ctclient get-roots --log_uri=${SRC_LOG_URI} --text=false > /tmp/hammercfg/roots.pem
 sed -i 's-""-"/tmp/hammercfg/roots.pem"-g' /tmp/hammercfg/hammer.cfg
 ```
@@ -141,15 +141,15 @@ sed -i 's-""-"/tmp/hammercfg/roots.pem"-g' /tmp/hammercfg/hammer.cfg
 Run TesseraCT with the same roots:
 
 ```bash
-cd ${SCTFE_REPO}
+cd ${TESSERACT_REPO}
 go run ./cmd/gcp/ \
   --bucket=${GOOGLE_PROJECT}-${TESSERA_BASE_NAME}-bucket \
   --spanner_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-db \
   --roots_pem_file=/tmp/hammercfg/roots.pem \
   --origin=${TESSERA_BASE_NAME} \
   --spanner_antispam_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-antispam-db \
-  --signer_public_key_secret_name=${SCTFE_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
-  --signer_private_key_secret_name=${SCTFE_SIGNER_ECDSA_P256_PRIVATE_KEY_ID} \
+  --signer_public_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
+  --signer_private_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID} \
   -v=3
 ```
 

--- a/deployment/live/gcp/test/README.md
+++ b/deployment/live/gcp/test/README.md
@@ -9,7 +9,7 @@ installed, and your favourite terminal multiplexer.
 ## Overview
 
 This config uses the [gcp/test](/deployment/modules/gcp/test) module to
-define a test environment to run the SCTFE, backed by Trillian Tessera.
+define a test environment to run TesseraCT, backed by Trillian Tessera.
 
 At a high level, this environment consists of:
 - One Spanner instance with two databases:
@@ -46,11 +46,11 @@ export SCTFE_SIGNER_ECDSA_P256_PUBLIC_KEY_ID=$(terragrunt output -raw ecdsa_p256
 export SCTFE_SIGNER_ECDSA_P256_PRIVATE_KEY_ID=$(terragrunt output -raw ecdsa_p256_private_key_id)
 ```
 
-## Run the SCTFE
+## Run TesseraCT
 
 ### With fake chains
 
-On the VM, run the following command to bring up the SCTFE:
+On the VM, run the following command to bring up TesseraCT:
 
 ```bash
 go run ./cmd/gcp/ \
@@ -80,7 +80,7 @@ openssl x509 -req -days 3650 -in /tmp/httpschain/cert.csr -CAkey internal/testda
 cat internal/testdata/fake-ca.cert >> /tmp/httpschain/chain.pem
 ```
 
-Finally, submit the chain to the SCTFE:
+Finally, submit the chain to TesseraCT:
 
 ```bash
 go run github.com/google/certificate-transparency-go/client/ctclient@master upload --cert_chain=/tmp/httpschain/chain.pem --skip_https_verify --log_uri=http://localhost:6962/${TESSERA_BASE_NAME}
@@ -88,7 +88,7 @@ go run github.com/google/certificate-transparency-go/client/ctclient@master uplo
 
 #### Automatically generate chains
 
-Save the SCTFE repo's path:
+Save TesseraCT repo's path:
 
 ```bash
 export SCTFE_REPO=$(pwd)
@@ -138,7 +138,7 @@ go run ./client/ctclient get-roots --log_uri=${SRC_LOG_URI} --text=false > /tmp/
 sed -i 's-""-"/tmp/hammercfg/roots.pem"-g' /tmp/hammercfg/hammer.cfg
 ```
 
-Run the SCTFE with the same roots:
+Run TesseraCT with the same roots:
 
 ```bash
 cd ${SCTFE_REPO}

--- a/deployment/modules/aws/secretsmanager/main.tf
+++ b/deployment/modules/aws/secretsmanager/main.tf
@@ -22,21 +22,9 @@ resource "aws_secretsmanager_secret" "tesseract_ecdsa_p256_public_key" {
   }
 }
 
-// TODO(phbnf): remove after migration
-moved {
-  from = aws_secretsmanager_secret.sctfe_ecdsa_p256_public_key
-  to   = aws_secretsmanager_secret.tesseract_ecdsa_p256_public_key
-}
-
 resource "aws_secretsmanager_secret_version" "tesseract_ecdsa_p256_public_key" {
   secret_id     = aws_secretsmanager_secret.tesseract_ecdsa_p256_public_key.id
   secret_string = var.tls_private_key_ecdsa_p256_public_key_pem
-}
-
-// TODO(phbnf): remove after migration
-moved {
-  from = aws_secretsmanager_secret_version.sctfe_ecdsa_p256_public_key
-  to   = aws_secretsmanager_secret_version.tesseract_ecdsa_p256_public_key
 }
 
 resource "aws_secretsmanager_secret" "tesseract_ecdsa_p256_private_key" {
@@ -48,19 +36,7 @@ resource "aws_secretsmanager_secret" "tesseract_ecdsa_p256_private_key" {
   }
 }
 
-// TODO(phbnf): remove after migration
-moved {
-  from = aws_secretsmanager_secret.sctfe_ecdsa_p256_private_key
-  to   = aws_secretsmanager_secret.tesseract_ecdsa_p256_private_key
-}
-
 resource "aws_secretsmanager_secret_version" "tesseract_ecdsa_p256_private_key" {
   secret_id     = aws_secretsmanager_secret.tesseract_ecdsa_p256_private_key.id
   secret_string = var.tls_private_key_ecdsa_p256_private_key_pem
-}
-
-// TODO(phbnf): remove after migration
-moved {
-  from = aws_secretsmanager_secret_version.sctfe_ecdsa_p256_private_key
-  to   =  aws_secretsmanager_secret_version.tesseract_ecdsa_p256_private_key
 }

--- a/deployment/modules/aws/secretsmanager/main.tf
+++ b/deployment/modules/aws/secretsmanager/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 }
 
 # Secrets Manager
-resource "aws_secretsmanager_secret" "sctfe_ecdsa_p256_public_key" {
+resource "aws_secretsmanager_secret" "tesseract_ecdsa_p256_public_key" {
   name = "${var.base_name}-ecdsa-p256-public-key"
   recovery_window_in_days = 0
 
@@ -22,12 +22,24 @@ resource "aws_secretsmanager_secret" "sctfe_ecdsa_p256_public_key" {
   }
 }
 
-resource "aws_secretsmanager_secret_version" "sctfe_ecdsa_p256_public_key" {
-  secret_id     = aws_secretsmanager_secret.sctfe_ecdsa_p256_public_key.id
+// TODO(phbnf): remove after migration
+moved {
+  from = aws_secretsmanager_secret.sctfe_ecdsa_p256_public_key
+  to   = aws_secretsmanager_secret.tesseract_ecdsa_p256_public_key
+}
+
+resource "aws_secretsmanager_secret_version" "tesseract_ecdsa_p256_public_key" {
+  secret_id     = aws_secretsmanager_secret.tesseract_ecdsa_p256_public_key.id
   secret_string = var.tls_private_key_ecdsa_p256_public_key_pem
 }
 
-resource "aws_secretsmanager_secret" "sctfe_ecdsa_p256_private_key" {
+// TODO(phbnf): remove after migration
+moved {
+  from = aws_secretsmanager_secret_version.sctfe_ecdsa_p256_public_key
+  to   = aws_secretsmanager_secret_version.tesseract_ecdsa_p256_public_key
+}
+
+resource "aws_secretsmanager_secret" "tesseract_ecdsa_p256_private_key" {
   name = "${var.base_name}-ecdsa-p256-private-key"
   recovery_window_in_days = 0
   
@@ -36,7 +48,19 @@ resource "aws_secretsmanager_secret" "sctfe_ecdsa_p256_private_key" {
   }
 }
 
-resource "aws_secretsmanager_secret_version" "sctfe_ecdsa_p256_private_key" {
-  secret_id     = aws_secretsmanager_secret.sctfe_ecdsa_p256_private_key.id
+// TODO(phbnf): remove after migration
+moved {
+  from = aws_secretsmanager_secret.sctfe_ecdsa_p256_private_key
+  to   = aws_secretsmanager_secret.tesseract_ecdsa_p256_private_key
+}
+
+resource "aws_secretsmanager_secret_version" "tesseract_ecdsa_p256_private_key" {
+  secret_id     = aws_secretsmanager_secret.tesseract_ecdsa_p256_private_key.id
   secret_string = var.tls_private_key_ecdsa_p256_private_key_pem
+}
+
+// TODO(phbnf): remove after migration
+moved {
+  from = aws_secretsmanager_secret_version.sctfe_ecdsa_p256_private_key
+  to   =  aws_secretsmanager_secret_version.tesseract_ecdsa_p256_private_key
 }

--- a/deployment/modules/aws/secretsmanager/outputs.tf
+++ b/deployment/modules/aws/secretsmanager/outputs.tf
@@ -1,15 +1,15 @@
 output "ecdsa_p256_public_key_id" {
   description = "Signer public key (P256_SHA256)"
-  value       = aws_secretsmanager_secret.sctfe_ecdsa_p256_public_key.name
+  value       = aws_secretsmanager_secret.tesseract_ecdsa_p256_public_key.name
 }
 
 output "ecdsa_p256_public_key_data" {
   description = "Signer public key (P256_SHA256) data from secret manager"
-  value       = aws_secretsmanager_secret_version.sctfe_ecdsa_p256_public_key.secret_string
+  value       = aws_secretsmanager_secret_version.tesseract_ecdsa_p256_public_key.secret_string
   sensitive   = true
 }
 
 output "ecdsa_p256_private_key_id" {
   description = "Signer private key (P256_SHA256)"
-  value       = aws_secretsmanager_secret.sctfe_ecdsa_p256_private_key.name
+  value       = aws_secretsmanager_secret.tesseract_ecdsa_p256_private_key.name
 }

--- a/deployment/modules/gcp/cloudbuild/conformance/main.tf
+++ b/deployment/modules/gcp/cloudbuild/conformance/main.tf
@@ -79,7 +79,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
     ## This will be used by the building the conformance Docker image which includes 
     ## the test data.
     step {
-      id   = "docker_build_sctfe_gcp"
+      id   = "docker_build_tesseract_gcp"
       name = "gcr.io/cloud-builders/docker"
       args = [
         "build",
@@ -101,7 +101,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
         "-f", "./cmd/gcp/ci/Dockerfile",
         "."
       ]
-      wait_for = ["docker_build_sctfe_gcp"]
+      wait_for = ["docker_build_tesseract_gcp"]
     }
 
     ## Push the conformance Docker container image to Artifact Registry.

--- a/deployment/modules/gcp/cloudbuild/conformance/main.tf
+++ b/deployment/modules/gcp/cloudbuild/conformance/main.tf
@@ -90,7 +90,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       ]
     }
 
-    ## Build the SCTFE GCP Conformance Docker container image.
+    ## Build TesseraCT GCP Conformance Docker container image.
     step {
       id   = "docker_build_conformance_gcp"
       name = "gcr.io/cloud-builders/docker"

--- a/deployment/modules/gcp/cloudbuild/conformance/main.tf
+++ b/deployment/modules/gcp/cloudbuild/conformance/main.tf
@@ -140,8 +140,8 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       id     = "terraform_print_output"
       name   = "alpine/terragrunt"
       script = <<EOT
-        terragrunt --terragrunt-no-color output --raw conformance_url -no-color > /workspace/conformance_url
-        terragrunt --terragrunt-no-color output --raw conformance_bucket_name -no-color > /workspace/conformance_bucket_name
+        terragrunt --terragrunt-no-color output --raw tesseract_url -no-color > /workspace/conformance_url
+        terragrunt --terragrunt-no-color output --raw tesseract_bucket_name -no-color > /workspace/conformance_bucket_name
         terragrunt --terragrunt-no-color output --raw ecdsa_p256_public_key_data -no-color > /workspace/conformance_log_public_key.pem
       EOT
       dir    = "deployment/live/gcp/static-ct/logs/ci"

--- a/deployment/modules/gcp/cloudbuild/tesseract/main.tf
+++ b/deployment/modules/gcp/cloudbuild/tesseract/main.tf
@@ -64,7 +64,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
     ## This will be used by the building the conformance Docker image which includes 
     ## the test data.
     step {
-      id   = "docker_build_sctfe_gcp"
+      id   = "docker_build_tesseract_gcp"
       name = "gcr.io/cloud-builders/docker"
       args = [
         "build",
@@ -86,7 +86,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
         "-f", "./cmd/gcp/staging/Dockerfile",
         "."
       ]
-      wait_for = ["docker_build_sctfe_gcp"]
+      wait_for = ["docker_build_tesseract_gcp"]
     }
 
     ## Push the conformance Docker container image to Artifact Registry.

--- a/deployment/modules/gcp/cloudbuild/tesseract/main.tf
+++ b/deployment/modules/gcp/cloudbuild/tesseract/main.tf
@@ -75,7 +75,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       ]
     }
 
-    ## Build the SCTFE GCP Conformance Docker container image.
+    ## Build TesseraCT GCP Conformance Docker container image.
     step {
       id   = "docker_build_conformance_gcp"
       name = "gcr.io/cloud-builders/docker"

--- a/deployment/modules/gcp/cloudbuild/tesseract/main.tf
+++ b/deployment/modules/gcp/cloudbuild/tesseract/main.tf
@@ -23,7 +23,8 @@ module "artifactregistry" {
 locals {
   cloudbuild_service_account   = "cloudbuild-${var.env}-sa@${var.project_id}.iam.gserviceaccount.com"
   artifact_repo                = "${var.location}-docker.pkg.dev/${var.project_id}/${module.artifactregistry.docker.name}"
-  conformance_gcp_docker_image = "${local.artifact_repo}/conformance-gcp"
+  ## TODO(phbnf): this should include the name of the log since it contains roots
+  tesseract_gcp_docker_image = "${local.artifact_repo}/tesseract-gcp"
 }
 
 resource "google_project_service" "cloudbuild_api" {
@@ -60,9 +61,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
   }
 
   build {
-    ## Build TesseraCT GCP Docker image.
-    ## This will be used by the building the conformance Docker image which includes 
-    ## the test data.
+    ## Build TesseraCT GCP Docker container image, without roots.
     step {
       id   = "docker_build_tesseract_gcp"
       name = "gcr.io/cloud-builders/docker"
@@ -75,41 +74,42 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       ]
     }
 
-    ## Build TesseraCT GCP Conformance Docker container image.
+    ## Build TesseraCT GCP Docker container image, with roots.
+    ## TODO(phbnf): make the docker file path a var.
     step {
-      id   = "docker_build_conformance_gcp"
+      id   = "docker_build_tesseract_with_roots_gcp"
       name = "gcr.io/cloud-builders/docker"
       args = [
         "build",
-        "-t", "${local.conformance_gcp_docker_image}:$SHORT_SHA",
-        "-t", "${local.conformance_gcp_docker_image}:latest",
+        "-t", "${local.tesseract_gcp_docker_image}:$SHORT_SHA",
+        "-t", "${local.tesseract_gcp_docker_image}:latest",
         "-f", "./cmd/gcp/staging/Dockerfile",
         "."
       ]
       wait_for = ["docker_build_tesseract_gcp"]
     }
 
-    ## Push the conformance Docker container image to Artifact Registry.
+    ## Push TesseraCT's Docker container image to Artifact Registry.
     step {
-      id   = "docker_push_conformance_gcp"
+      id   = "docker_push_tesseract_gcp"
       name = "gcr.io/cloud-builders/docker"
       args = [
         "push",
         "--all-tags",
-        local.conformance_gcp_docker_image
+        local.tesseract_gcp_docker_image
       ]
-      wait_for = ["docker_build_conformance_gcp"]
+      wait_for = ["docker_build_tesseract_with_roots_gcp"]
     }
 
     ## Apply the deployment/live/gcp/static-staging/logs/XXX terragrunt configs.
-    ## This will bring up or update the conformance infrastructure, including a service
+    ## This will bring up or update TesseraCT's infrastructure, including a service
     ## running the conformance server docker image built above.
     dynamic "step" {
       for_each = var.logs_terragrunts
       iterator = tg_path
 
       content {
-        id     = "terraform_apply_conformance_staging_${tg_path.key}"
+        id     = "terraform_apply_tesseract_${tg_path.key}"
         name   = "alpine/terragrunt"
         script = <<EOT
           terragrunt --terragrunt-non-interactive --terragrunt-no-color apply -auto-approve -no-color 2>&1
@@ -122,7 +122,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
           "TF_VAR_project_id=${var.project_id}",
           "DOCKER_CONTAINER_TAG=$SHORT_SHA"
         ]
-        wait_for = tg_path.key > 0 ? ["docker_push_conformance_gcp", "terraform_apply_conformance_staging_${tg_path.key - 1}"] : ["docker_push_conformance_gcp"]
+        wait_for = tg_path.key > 0 ? ["docker_push_tesseract_gcp", "terraform_apply_tesseract_${tg_path.key - 1}"] : ["docker_push_tesseract_gcp"]
       }
     }
 
@@ -135,12 +135,12 @@ resource "google_cloudbuild_trigger" "build_trigger" {
         id     = "terraform_print_output_${tg_path.key}"
         name   = "alpine/terragrunt"
         script = <<EOT
-          terragrunt --terragrunt-no-color output --raw conformance_url -no-color > /workspace/conformance_url
-          terragrunt --terragrunt-no-color output --raw conformance_bucket_name -no-color > /workspace/conformance_bucket_name
-          terragrunt --terragrunt-no-color output --raw ecdsa_p256_public_key_data -no-color > /workspace/conformance_log_public_key.pem
-          cat /workspace/conformance_url
-          cat /workspace/conformance_bucket_name
-          cat /workspace/conformance_log_public_key.pem
+          terragrunt --terragrunt-no-color output --raw tesseract_url -no-color > /workspace/tesseract_url
+          terragrunt --terragrunt-no-color output --raw tesseract_bucket_name -no-color > /workspace/tesseract_bucket_name
+          terragrunt --terragrunt-no-color output --raw ecdsa_p256_public_key_data -no-color > /workspace/tesseract_log_public_key.pem
+          cat /workspace/tesseract_url
+          cat /workspace/tesseract_bucket_name
+          cat /workspace/tesseract_log_public_key.pem
         EOT
         dir    = tg_path.value
         env = [
@@ -150,7 +150,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
           "TF_VAR_project_id=${var.project_id}",
           "DOCKER_CONTAINER_TAG=$SHORT_SHA"
         ]
-        wait_for = ["terraform_apply_conformance_staging_${tg_path.key}"]
+        wait_for = ["terraform_apply_tesseract_${tg_path.key}"]
       }
     }
 

--- a/deployment/modules/gcp/cloudbuild/tesseract/main.tf
+++ b/deployment/modules/gcp/cloudbuild/tesseract/main.tf
@@ -103,7 +103,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
 
     ## Apply the deployment/live/gcp/static-staging/logs/XXX terragrunt configs.
     ## This will bring up or update TesseraCT's infrastructure, including a service
-    ## running the conformance server docker image built above.
+    ## running the server docker image built above.
     dynamic "step" {
       for_each = var.logs_terragrunts
       iterator = tg_path

--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -37,7 +37,7 @@ resource "google_cloud_run_v2_service" "default" {
 
     containers {
       image = var.server_docker_image
-      name  = "conformance"
+      name  = "tesseract"
       args = [
         "--logtostderr",
         "--v=1",

--- a/deployment/modules/gcp/cloudrun/outputs.tf
+++ b/deployment/modules/gcp/cloudrun/outputs.tf
@@ -1,4 +1,4 @@
-output "conformance_url" {
-  description = "The URL of the running conformance server"
+output "tesseract_url" {
+  description = "The submission URL of the running TesseraCT server"
   value       = google_cloud_run_v2_service.default.uri
 }

--- a/deployment/modules/gcp/secretmanager/main.tf
+++ b/deployment/modules/gcp/secretmanager/main.tf
@@ -22,16 +22,16 @@ resource "google_project_service" "secretmanager_googleapis_com" {
 # recommended.
 #
 # See https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key.
-resource "tls_private_key" "sctfe_ecdsa_p256" {
+resource "tls_private_key" "tesseract_ecdsa_p256" {
   algorithm   = "ECDSA"
   ecdsa_curve = "P256"
 }
 
-resource "google_secret_manager_secret" "sctfe_ecdsa_p256_public_key" {
+resource "google_secret_manager_secret" "tesseract_ecdsa_p256_public_key" {
   secret_id = "${var.base_name}-ecdsa-p256-public-key"
 
   labels = {
-    label = "sctfe-public-key"
+    label = "tesseract-public-key"
   }
 
   replication {
@@ -41,17 +41,17 @@ resource "google_secret_manager_secret" "sctfe_ecdsa_p256_public_key" {
   depends_on = [google_project_service.secretmanager_googleapis_com]
 }
 
-resource "google_secret_manager_secret_version" "sctfe_ecdsa_p256_public_key" {
-  secret = google_secret_manager_secret.sctfe_ecdsa_p256_public_key.id
+resource "google_secret_manager_secret_version" "tesseract_ecdsa_p256_public_key" {
+  secret = google_secret_manager_secret.tesseract_ecdsa_p256_public_key.id
 
-  secret_data = tls_private_key.sctfe_ecdsa_p256.public_key_pem
+  secret_data = tls_private_key.tesseract_ecdsa_p256.public_key_pem
 }
 
-resource "google_secret_manager_secret" "sctfe_ecdsa_p256_private_key" {
+resource "google_secret_manager_secret" "tesseract_ecdsa_p256_private_key" {
   secret_id = "${var.base_name}-ecdsa-p256-private-key"
 
   labels = {
-    label = "sctfe-private-key"
+    label = "tesseract-private-key"
   }
 
   replication {
@@ -61,8 +61,8 @@ resource "google_secret_manager_secret" "sctfe_ecdsa_p256_private_key" {
   depends_on = [google_project_service.secretmanager_googleapis_com]
 }
 
-resource "google_secret_manager_secret_version" "sctfe_ecdsa_p256_private_key" {
-  secret = google_secret_manager_secret.sctfe_ecdsa_p256_private_key.id
+resource "google_secret_manager_secret_version" "tesseract_ecdsa_p256_private_key" {
+  secret = google_secret_manager_secret.tesseract_ecdsa_p256_private_key.id
 
-  secret_data = tls_private_key.sctfe_ecdsa_p256.private_key_pem
+  secret_data = tls_private_key.tesseract_ecdsa_p256.private_key_pem
 }

--- a/deployment/modules/gcp/secretmanager/main.tf
+++ b/deployment/modules/gcp/secretmanager/main.tf
@@ -27,6 +27,12 @@ resource "tls_private_key" "tesseract_ecdsa_p256" {
   ecdsa_curve = "P256"
 }
 
+// TODO(phbnf): remove after migration
+moved {
+  from = tls_private_key.sctfe_ecdsa_p256
+  to   = tls_private_key.tesseract_ecdsa_p256
+}
+
 resource "google_secret_manager_secret" "tesseract_ecdsa_p256_public_key" {
   secret_id = "${var.base_name}-ecdsa-p256-public-key"
 
@@ -41,10 +47,22 @@ resource "google_secret_manager_secret" "tesseract_ecdsa_p256_public_key" {
   depends_on = [google_project_service.secretmanager_googleapis_com]
 }
 
+// TODO(phbnf): remove after migration
+moved {
+  from = google_secret_manager_secret.sctfe_ecdsa_p256_public_key
+  to = google_secret_manager_secret.tesseract_ecdsa_p256_public_key
+}
+
 resource "google_secret_manager_secret_version" "tesseract_ecdsa_p256_public_key" {
   secret = google_secret_manager_secret.tesseract_ecdsa_p256_public_key.id
 
   secret_data = tls_private_key.tesseract_ecdsa_p256.public_key_pem
+}
+
+// TODO(phbnf): remove after migration
+moved {
+  from = google_secret_manager_secret_version.sctfe_ecdsa_p256_public_key
+  to = google_secret_manager_secret_version.tesseract_ecdsa_p256_public_key
 }
 
 resource "google_secret_manager_secret" "tesseract_ecdsa_p256_private_key" {
@@ -61,8 +79,20 @@ resource "google_secret_manager_secret" "tesseract_ecdsa_p256_private_key" {
   depends_on = [google_project_service.secretmanager_googleapis_com]
 }
 
+// TODO(phbnf): remove after migration
+moved {
+  from = google_secret_manager_secret.sctfe_ecdsa_p256_private_key
+  to = google_secret_manager_secret.tesseract_ecdsa_p256_private_key
+}
+
 resource "google_secret_manager_secret_version" "tesseract_ecdsa_p256_private_key" {
   secret = google_secret_manager_secret.tesseract_ecdsa_p256_private_key.id
 
   secret_data = tls_private_key.tesseract_ecdsa_p256.private_key_pem
+}
+
+// TODO(phbnf): remove after migration
+moved {
+  from = google_secret_manager_secret_version.sctfe_ecdsa_p256_private_key
+  to = google_secret_manager_secret_version.tesseract_ecdsa_p256_private_key
 }

--- a/deployment/modules/gcp/secretmanager/main.tf
+++ b/deployment/modules/gcp/secretmanager/main.tf
@@ -27,12 +27,6 @@ resource "tls_private_key" "tesseract_ecdsa_p256" {
   ecdsa_curve = "P256"
 }
 
-// TODO(phbnf): remove after migration
-moved {
-  from = tls_private_key.sctfe_ecdsa_p256
-  to   = tls_private_key.tesseract_ecdsa_p256
-}
-
 resource "google_secret_manager_secret" "tesseract_ecdsa_p256_public_key" {
   secret_id = "${var.base_name}-ecdsa-p256-public-key"
 
@@ -47,22 +41,10 @@ resource "google_secret_manager_secret" "tesseract_ecdsa_p256_public_key" {
   depends_on = [google_project_service.secretmanager_googleapis_com]
 }
 
-// TODO(phbnf): remove after migration
-moved {
-  from = google_secret_manager_secret.sctfe_ecdsa_p256_public_key
-  to = google_secret_manager_secret.tesseract_ecdsa_p256_public_key
-}
-
 resource "google_secret_manager_secret_version" "tesseract_ecdsa_p256_public_key" {
   secret = google_secret_manager_secret.tesseract_ecdsa_p256_public_key.id
 
   secret_data = tls_private_key.tesseract_ecdsa_p256.public_key_pem
-}
-
-// TODO(phbnf): remove after migration
-moved {
-  from = google_secret_manager_secret_version.sctfe_ecdsa_p256_public_key
-  to = google_secret_manager_secret_version.tesseract_ecdsa_p256_public_key
 }
 
 resource "google_secret_manager_secret" "tesseract_ecdsa_p256_private_key" {
@@ -79,20 +61,8 @@ resource "google_secret_manager_secret" "tesseract_ecdsa_p256_private_key" {
   depends_on = [google_project_service.secretmanager_googleapis_com]
 }
 
-// TODO(phbnf): remove after migration
-moved {
-  from = google_secret_manager_secret.sctfe_ecdsa_p256_private_key
-  to = google_secret_manager_secret.tesseract_ecdsa_p256_private_key
-}
-
 resource "google_secret_manager_secret_version" "tesseract_ecdsa_p256_private_key" {
   secret = google_secret_manager_secret.tesseract_ecdsa_p256_private_key.id
 
   secret_data = tls_private_key.tesseract_ecdsa_p256.private_key_pem
-}
-
-// TODO(phbnf): remove after migration
-moved {
-  from = google_secret_manager_secret_version.sctfe_ecdsa_p256_private_key
-  to = google_secret_manager_secret_version.tesseract_ecdsa_p256_private_key
 }

--- a/deployment/modules/gcp/secretmanager/outputs.tf
+++ b/deployment/modules/gcp/secretmanager/outputs.tf
@@ -1,15 +1,15 @@
 output "ecdsa_p256_public_key_id" {
   description = "Signer public key (P256_SHA256)"
-  value       = google_secret_manager_secret_version.sctfe_ecdsa_p256_public_key.id
+  value       = google_secret_manager_secret_version.tesseract_ecdsa_p256_public_key.id
 }
 
 output "ecdsa_p256_public_key_data" {
   description = "Signer public key (P256_SHA256) data from secret manager"
-  value       = google_secret_manager_secret_version.sctfe_ecdsa_p256_public_key.secret_data
+  value       = google_secret_manager_secret_version.tesseract_ecdsa_p256_public_key.secret_data
   sensitive   = true
 }
 
 output "ecdsa_p256_private_key_id" {
   description = "Signer private key (P256_SHA256)"
-  value       = google_secret_manager_secret_version.sctfe_ecdsa_p256_private_key.id
+  value       = google_secret_manager_secret_version.tesseract_ecdsa_p256_private_key.id
 }

--- a/deployment/modules/gcp/tesseract/cloudrun/outputs.tf
+++ b/deployment/modules/gcp/tesseract/cloudrun/outputs.tf
@@ -16,7 +16,7 @@ output "ecdsa_p256_private_key_id" {
 
 output "tesseract_url" {
   description = "The submission URL of the running TesseraCT server"
-  value       = module.cloudrun.conformance_url
+  value       = module.cloudrun.tesseract_url
 }
 
 output "tesseract_bucket_name" {

--- a/deployment/modules/gcp/tesseract/cloudrun/outputs.tf
+++ b/deployment/modules/gcp/tesseract/cloudrun/outputs.tf
@@ -14,12 +14,12 @@ output "ecdsa_p256_private_key_id" {
   value       = module.secretmanager.ecdsa_p256_private_key_id
 }
 
-output "conformance_url" {
-  description = "The URL of the running conformance server"
+output "tesseract_url" {
+  description = "The submission URL of the running TesseraCT server"
   value       = module.cloudrun.conformance_url
 }
 
-output "conformance_bucket_name" {
-  description = "The GCS bucket name of the running conformance server"
+output "tesseract_bucket_name" {
+  description = "The GCS bucket name of the TesseraCT log"
   value       = module.storage.log_bucket.name
 }

--- a/internal/ct/handlers.go
+++ b/internal/ct/handlers.go
@@ -176,7 +176,7 @@ func (a appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type HandlerOptions struct {
 	// Deadline is a timeout for HTTP requests.
 	Deadline time.Duration
-	// RequestLog provides structured logging of CTFE requests.
+	// RequestLog provides structured logging of TesseraCT requests.
 	RequestLog requestLog
 	// MaskInternalErrors indicates if internal server errors should be masked
 	// or returned to the user containing the full error message.

--- a/internal/ct/requestlog.go
+++ b/internal/ct/requestlog.go
@@ -25,9 +25,9 @@ import (
 
 const vLevel = 9
 
-// requestLog allows implementations to do structured logging of CTFE
+// requestLog allows implementations to do structured logging of TesseraCT
 // request parameters, submitted chains and other internal details that
-// are useful for log operators when debugging issues. CTFE handlers will
+// are useful for log operators when debugging issues. TesseraCT handlers will
 // call the appropriate methods during request processing. The implementation
 // is responsible for collating and storing the resulting logging information.
 type requestLog interface {


### PR DESCRIPTION
Towards #267.

Configs have been pushed to `arche2025{h1,h2}`, and work. I haven't tried for the conformance tests though, but I've done little changes (if not 0) for these, so it _should_ work, and we'll fix it if it doesn't!