### PR TITLE
Fetcher checks content type

### DIFF
--- a/internal/types/staticct/staticct.go
+++ b/internal/types/staticct/staticct.go
@@ -25,8 +25,10 @@ import (
 )
 
 const (
-	IssuersPrefix      = "issuer/"
-	IssuersContentType = "application/pkix-cert"
+	IssuersPrefix         = "issuer/"
+	IssuersContentType    = "application/pkix-cert"
+	CheckpointContentType = "text/plain; charset=utf-8"
+	TreeContentType       = "application/octet-stream"
 )
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Matching PR incoming to tessera if you're happy with it!

This PR checks that Content-Type is exactly of length 1, and that it has the content type specified in specs. We could be a bit more lax and use `slices.Contains`, especially since the Content-Type header could be set multiple times if I understand correctly, but this would deviate a bit from specs.