### PR TITLE
Don't error if someone else created the directory

### DIFF
--- a/storage/posix/file_ops.go
+++ b/storage/posix/file_ops.go
@@ -63,7 +63,7 @@ func mkdirAll(name string, perm os.FileMode) (err error) {
 		// We'll see an ENOENT if there's a problem with a non-existant path element, so
 		// we'll recurse and create the parent directory if necessary.
 		if dir != "" {
-			if err := mkdirAll(dir, perm); err != nil {
+			if err := mkdirAll(dir, perm); err != nil && !errors.Is(err, os.ErrExist) {
 				return err
 			}
 		}


### PR DESCRIPTION
This PR avoids an error if two routines end up racing to create a directory.
POSIX `mkdir` is atomic, so no need to try to sort this out with mutexes.