### PR TITLE
Bump tessera to ac0ba0aa82a0e52002cece997f149fceba7a3e7c

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,9 +25,9 @@ require (
 	github.com/johannesboyne/gofakes3 v0.0.0-20250916175020-ebf3e50324d3
 	github.com/kylelemons/godebug v1.1.0
 	github.com/rivo/tview v0.42.0
-	github.com/transparency-dev/formats v0.0.0-20250421220931-bb8ad4d07c26
+	github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c
 	github.com/transparency-dev/merkle v0.0.2
-	github.com/transparency-dev/tessera v1.0.1-0.20250930174249-112eca49fafd
+	github.com/transparency-dev/tessera v1.0.1-0.20251017111740-ac0ba0aa82a0
 	go.opentelemetry.io/contrib/detectors/gcp v1.38.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.38.0

--- a/go.sum
+++ b/go.sum
@@ -1063,12 +1063,12 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tinylib/msgp v1.3.0 h1:ULuf7GPooDaIlbyvgAxBV/FI7ynli6LZ1/nVUNu+0ww=
 github.com/tinylib/msgp v1.3.0/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
-github.com/transparency-dev/formats v0.0.0-20250421220931-bb8ad4d07c26 h1:YTbkeFbzcer+42bIgo6Za2194nKwhZPgaZKsP76QffE=
-github.com/transparency-dev/formats v0.0.0-20250421220931-bb8ad4d07c26/go.mod h1:ODywn0gGarHMMdSkWT56ULoK8Hk71luOyRseKek9COw=
+github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ2LiAUV+/RjckMyq9sXudfrPSuCY4FuPC1NyAw=
+github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/transparency-dev/tessera v1.0.1-0.20250930174249-112eca49fafd h1:L0OqwjeqtzYOesvII91GUwoq7igDPMSI8X74muuTud0=
-github.com/transparency-dev/tessera v1.0.1-0.20250930174249-112eca49fafd/go.mod h1:LnaHEpxUOmlAeLOUqjR3Z8gV1j/9TqytFNT63L9wPoo=
+github.com/transparency-dev/tessera v1.0.1-0.20251017111740-ac0ba0aa82a0 h1:/2/Ox9QuZ7Qe3xZ1zQscJ2mQfK9tKDGpdEZV1zT373Y=
+github.com/transparency-dev/tessera v1.0.1-0.20251017111740-ac0ba0aa82a0/go.mod h1:fuJ8I55c94wyIWC3m+xz0zkWn1V0H0vXMYi8Y+JQE+s=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This brings in, via tessera, support for 0x04 Cosignature vkeys in the witness policy file.