### PR TITLE
Add rgdd-1 witness to arche logs

### DIFF
--- a/deployment/live/gcp/static-ct-staging/logs/witness.policy
+++ b/deployment/live/gcp/static-ct-staging/logs/witness.policy
@@ -4,8 +4,9 @@
 witness tf-1 transparency.dev/DEV:witness-little-garden+4b7fca75+AStusOxINQNUTN5Oj8HObRkh2yHf/MwYaGX4CPdiVEPM https://api.transparency.dev/dev/witness/little-garden 
 witness remora-1 remora.n621.de+da77ade7+BOvN63jn/bLvkieywe8R6UYAtVtNbZpXh34x7onlmtw2 https://remora.n621.de/
 witness smartit-1 witness1.smartit.nu/witness1+a48c820f+BPSFWg9G6KPiO7QPryYO5Xq4oYJJ+kAvLKLSimDhoxMO https://witness1.smartit.nu/witness1
+witness rgdd-1 rgdd.se/poc-witness+db03732e+BCjJKlo6BU0xfIb8LutqerIFTWIXEA0L5n3tW3QyPFgG https://bastion.glasklar.is/70b861a010f25030de6ff6a5267e0b951e70c04b20ba4a3ce41e7fba7b9b7dfc
 
-group dev_grp all tf-1 remora-1 smartit-1
+group dev_grp all tf-1 remora-1 smartit-1 rgdd-1
 
 ## AW CI devices
 witness aw1 ArmoredWitness-wispy-snow+834b82b1+ASho7B13t7PhXoLr43ppVFCHEpTSajIybNRYMSi8XR1Q   https://bastion.glasklar.is/ea8a7b22bb1a6420464bab7a01f768f120cf237bb399b46d0973109059175264


### PR DESCRIPTION
Adds the [rgdd poc witness](https://www.rgdd.se/poc-witness/about) to the arche staging logs.