### PR TITLE
Add GitHub Actions workflow to build POSIX tesseract with ko

### DIFF
--- a/.github/workflows/ko-build-posix.yml
+++ b/.github/workflows/ko-build-posix.yml
@@ -1,0 +1,45 @@
+name: Build POSIX Tesseract with ko
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-posix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install ko
+        uses: ko-build/setup-ko@3aebd0597dc1e9d1a26bcfdb7cbeb19c131d3037 # v0.7
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push POSIX tesseract with ko
+        run: |
+          ko build ./cmd/tesseract/posix \
+            --bare \
+            --platform=linux/amd64 \
+            --tags latest,${{ github.sha }}
+        env:
+          KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/tesseract
+
+      - name: Output image reference
+        run: |
+          echo "Image pushed to: ghcr.io/${{ github.repository_owner }}/tesseract/posix:latest"
+          echo "Image pushed to: ghcr.io/${{ github.repository_owner }}/tesseract/posix:${{ github.sha }}"

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: gcr.io/distroless/static-debian12:nonroot


### PR DESCRIPTION
Adds a manual workflow that builds the POSIX tesseract binary using ko and pushes the resulting container image to GitHub Container Registry.

Changes:
- Add .ko.yaml to configure static distroless base image
- Add workflow to build and push to ghcr.io
- Workflow tags images with both 'latest' and commit SHA
- Uses gcr.io/distroless/static-debian12:nonroot as base image