### PR TITLE
Conditionally enable health checks

### DIFF
--- a/deployment/modules/gcp/gce/tesseract/variables.tf
+++ b/deployment/modules/gcp/gce/tesseract/variables.tf
@@ -122,3 +122,9 @@ variable "witness_policy" {
   type        = string
   default     = ""
 }
+
+variable "health_checks" {
+  description = "If true, enables GCE health checks."
+  type        = bool
+  default     = true
+}

--- a/deployment/modules/gcp/tesseract/gce/main.tf
+++ b/deployment/modules/gcp/tesseract/gce/main.tf
@@ -45,6 +45,7 @@ module "gce" {
   rate_limit_old_not_before                  = var.rate_limit_old_not_before
   rate_limit_dedup                           = var.rate_limit_dedup
   witness_policy                             = var.witness_policy
+  health_checks                              = var.gce_health_checks
 
   depends_on = [
     module.secretmanager,

--- a/deployment/modules/gcp/tesseract/gce/variables.tf
+++ b/deployment/modules/gcp/tesseract/gce/variables.tf
@@ -121,3 +121,9 @@ variable "additional_signer_private_key_secret_names" {
   description = "List of additional private key secret name for checkpoint secondary signers. Format: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}. These secrets MUST be formatted as serialised note signers."
   type        = list(string)
 }
+
+variable "gce_health_checks" {
+  description = "If true, enables GCE health checks."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This PR makes it possible to disable GCE health checks, which can prevent terraform from returning when it bring MIGs up.