### PR TITLE
Migrate preloader to cloud-init

### DIFF
--- a/deployment/modules/gcp/gce/preloader/main.tf
+++ b/deployment/modules/gcp/gce/preloader/main.tf
@@ -77,6 +77,9 @@ resource "google_compute_instance" "preloader" {
 
   network_interface {
     network = "default"
+    access_config {
+      // Ephemeral public IP for outbound witness requests.
+    }
   }
 
   boot_disk {


### PR DESCRIPTION
This PR migrates the preloader terraform config away from the deprecated container-vm approach over to using `cloud-init`.