### PR TITLE
Disable linter for x509 fork

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,4 @@ jobs:
         uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9.1.0
         with:
           version: v2.1.6
-          args: --timeout=5m
+          args: --timeout=5m --skip-dirs=internal/lax509


### PR DESCRIPTION
No need to lint this when we don't want to make any changes to the fork.
