### PR TITLE
Disable manual KO triggers, and add release tag to built images.

### DIFF
--- a/.github/workflows/ko_build.yml
+++ b/.github/workflows/ko_build.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  release:
+    types:
+      - 'published'
   push:
     branches:
       - 'main'
@@ -49,7 +52,7 @@ jobs:
           image_and_digest=$(ko publish \
             --base-import-paths \
             --platform=linux/amd64,linux/arm64 \
-            --tags=latest,${{ github.sha }} \
+            --tags=latest,${{ github.sha }},${{ github.event.release.tag_name }} \
             --sbom-dir=${GITHUB_WORKSPACE}/sbom-output \
             github.com/transparency-dev/tesseract/cmd/${BINARY})
 


### PR DESCRIPTION
This PR:
- Removes the ability to manually trigger KO builds on arbitrary commits. This is probably not what we want as we end up with attested images which can contain arbitrary code
- Adds the release tag name (if any) to builds triggered when publishing a release (this should include both pre and final releases)