### PR TITLE
move to debian13 base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: gcr.io/distroless/static-debian12:nonroot
+defaultBaseImage: gcr.io/distroless/static-debian13:nonroot


### PR DESCRIPTION
distroless is now publishing debian13 images... there's not a lot inside the static image to begin with, but better to track a newer OS IMO.