### PR TITLE
Safe issuer storage init

### DIFF
--- a/storage/aws/issuers_test.go
+++ b/storage/aws/issuers_test.go
@@ -77,19 +77,19 @@ func newTestStorage(t *testing.T, bucket string) (*aws.Config, func(*s3.Options)
 
 func TestNewIssuerStorage(t *testing.T) {
 	tests := []struct {
-		name    string
-		path    string
-		wantErr bool
+		name       string
+		wantBucket string
+		wantErr    bool
 	}{
 		{
-			name:    "valid path",
-			path:    "",
-			wantErr: false,
+			name:       "valid bucket",
+			wantBucket: testBucket,
+			wantErr:    false,
 		},
 		{
-			name:    "non-existent path",
-			path:    "nonexistent",
-			wantErr: false,
+			name:       "non-existing bucket",
+			wantBucket: "shovel",
+			wantErr:    true,
 		},
 	}
 
@@ -98,7 +98,7 @@ func TestNewIssuerStorage(t *testing.T) {
 			cfg, opts, done := newTestStorage(t, testBucket)
 			defer done()
 
-			_, err := NewIssuerStorage(t.Context(), Options{Bucket: testBucket, SDKConfig: cfg, S3Options: opts})
+			_, err := NewIssuerStorage(t.Context(), Options{Bucket: tt.wantBucket, SDKConfig: cfg, S3Options: opts})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewIssuerStorage() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/storage/gcp/issuers.go
+++ b/storage/gcp/issuers.go
@@ -52,8 +52,14 @@ func NewIssuerStorage(ctx context.Context, bucket string, gcsClient *gcs.Client)
 		gcsClient = c
 	}
 
+	bkt := gcsClient.Bucket(bucket)
+	// Check that the bucket exists and that we have access to it.
+	if _, err := bkt.Attrs(ctx); err != nil {
+		return nil, fmt.Errorf("error checking GCS bucket %q: %w", bucket, err)
+	}
+
 	r := &IssuersStorage{
-		bucket:      gcsClient.Bucket(bucket),
+		bucket:      bkt,
 		prefix:      staticct.IssuersPrefix,
 		contentType: staticct.IssuersContentType,
 	}

--- a/storage/gcp/issuers_test.go
+++ b/storage/gcp/issuers_test.go
@@ -54,19 +54,19 @@ func newTestStorage(t *testing.T, bucket string) *fakestorage.Server {
 
 func TestNewIssuerStorage(t *testing.T) {
 	tests := []struct {
-		name    string
-		path    string
-		wantErr bool
+		name       string
+		wantBucket string
+		wantErr    bool
 	}{
 		{
-			name:    "valid path",
-			path:    "",
-			wantErr: false,
+			name:       "valid bucket",
+			wantBucket: testBucket,
+			wantErr:    false,
 		},
 		{
-			name:    "non-existent path",
-			path:    "nonexistent",
-			wantErr: false,
+			name:       "non-existing bucket",
+			wantBucket: "shovel",
+			wantErr:    true,
 		},
 	}
 
@@ -75,7 +75,7 @@ func TestNewIssuerStorage(t *testing.T) {
 			srv := newTestStorage(t, testBucket)
 			defer srv.Stop()
 
-			_, err := NewIssuerStorage(t.Context(), testBucket, srv.Client())
+			_, err := NewIssuerStorage(t.Context(), tt.wantBucket, srv.Client())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewIssuerStorage() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/storage/posix/issuers.go
+++ b/storage/posix/issuers.go
@@ -34,13 +34,15 @@ type IssuersStorage struct {
 
 // NewIssuerStorage creates a new POSIX based issuer storage.
 //
+// If the directory doesn't exists, NewIssuerStorage creates it and its parents.
 // The issuers will be stored in a directory called "issuer" within the provided root directory.
-func NewIssuerStorage(ctx context.Context, dir string) (*IssuersStorage, error) {
-	r := &IssuersStorage{
-		dir: filepath.Join(dir, staticct.IssuersPrefix),
+func NewIssuerStorage(ctx context.Context, root string) (*IssuersStorage, error) {
+	dir := filepath.Join(root, staticct.IssuersPrefix)
+	if err := mkdirAll(dir, dirPerm); err != nil {
+		return nil, fmt.Errorf("failed to make directory structure: %w", err)
 	}
 
-	return r, nil
+	return &IssuersStorage{dir}, nil
 }
 
 // AddIssuers stores Issuers values under their Key if there isn't an object under Key already.

--- a/storage/posix/issuers_test.go
+++ b/storage/posix/issuers_test.go
@@ -30,24 +30,24 @@ func TestNewIssuerStorage(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		path    string
+		root    string
 		wantErr bool
 	}{
 		{
-			name:    "valid path",
-			path:    "",
+			name:    "existing root",
+			root:    "",
 			wantErr: false,
 		},
 		{
-			name:    "non-existent path",
-			path:    "nonexistent",
+			name:    "non-existing root",
+			root:    "sho/vel",
 			wantErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewIssuerStorage(t.Context(), filepath.Join(tmpDir, tt.path))
+			_, err := NewIssuerStorage(t.Context(), filepath.Join(tmpDir, tt.root))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewIssuerStorage() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Towards #212 

This PR:
  - On AWS and GCP, checks that the buckets passed for issuers exists. The tests and method docstring were wrong.
  - On POSIX, creates the issuer directory if it doesn't exist already.

It's not entirely necessary, but doesn't hurt either, and will fail early rather than when requests start flying in. I haven't gone all the way to check that IAM is setup properly to allow writes, but I'll do that for root storage.