### PR TITLE
Remove GCS and S3 permission check

### DIFF
--- a/storage/aws/issuers.go
+++ b/storage/aws/issuers.go
@@ -52,8 +52,6 @@ type Options struct {
 }
 
 // NewIssuerStorage creates a new IssuerStorage.
-//
-// The specified bucket must exist or an error will be returned.
 func NewIssuerStorage(ctx context.Context, opts Options) (*IssuersStorage, error) {
 	var sdkConfig aws.Config
 	if opts.SDKConfig != nil {
@@ -69,14 +67,8 @@ func NewIssuerStorage(ctx context.Context, opts Options) (*IssuersStorage, error
 		opts.S3Options = func(_ *s3.Options) {}
 	}
 
-	s3Client := s3.NewFromConfig(sdkConfig, opts.S3Options)
-	// Check that the bucket exists and that we have access to it.
-	if _, err := s3Client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(opts.Bucket)}); err != nil {
-		return nil, fmt.Errorf("error checking S3 bucket %q: %w", opts.Bucket, err)
-	}
-
 	r := &IssuersStorage{
-		s3Client:    s3Client,
+		s3Client:    s3.NewFromConfig(sdkConfig, opts.S3Options),
 		bucket:      opts.Bucket,
 		prefix:      staticct.IssuersPrefix,
 		contentType: staticct.IssuersContentType,

--- a/storage/aws/issuers_test.go
+++ b/storage/aws/issuers_test.go
@@ -77,19 +77,12 @@ func newTestStorage(t *testing.T, bucket string) (*aws.Config, func(*s3.Options)
 
 func TestNewIssuerStorage(t *testing.T) {
 	tests := []struct {
-		name       string
-		wantBucket string
-		wantErr    bool
+		name   string
+		bucket string
 	}{
 		{
-			name:       "valid bucket",
-			wantBucket: testBucket,
-			wantErr:    false,
-		},
-		{
-			name:       "non-existing bucket",
-			wantBucket: "shovel",
-			wantErr:    true,
+			name:   "valid bucket",
+			bucket: testBucket,
 		},
 	}
 
@@ -98,9 +91,9 @@ func TestNewIssuerStorage(t *testing.T) {
 			cfg, opts, done := newTestStorage(t, testBucket)
 			defer done()
 
-			_, err := NewIssuerStorage(t.Context(), Options{Bucket: tt.wantBucket, SDKConfig: cfg, S3Options: opts})
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewIssuerStorage() error = %v, wantErr %v", err, tt.wantErr)
+			_, err := NewIssuerStorage(t.Context(), Options{Bucket: tt.bucket, SDKConfig: cfg, S3Options: opts})
+			if err != nil {
+				t.Errorf("NewIssuerStorage() error = %v", err)
 				return
 			}
 		})

--- a/storage/gcp/issuers.go
+++ b/storage/gcp/issuers.go
@@ -40,9 +40,7 @@ type IssuersStorage struct {
 	contentType string
 }
 
-// NewIssuerStorage creates a new GCSStorage.
-//
-// The specified bucket must exist or an error will be returned.
+// NewIssuerStorage creates a new GCSStorage and GCS client.
 func NewIssuerStorage(ctx context.Context, bucket string, gcsClient *gcs.Client) (*IssuersStorage, error) {
 	if gcsClient == nil {
 		c, err := gcs.NewClient(ctx, gcs.WithJSONReads())
@@ -52,14 +50,8 @@ func NewIssuerStorage(ctx context.Context, bucket string, gcsClient *gcs.Client)
 		gcsClient = c
 	}
 
-	bkt := gcsClient.Bucket(bucket)
-	// Check that the bucket exists and that we have access to it.
-	if _, err := bkt.Attrs(ctx); err != nil {
-		return nil, fmt.Errorf("error checking GCS bucket %q: %w", bucket, err)
-	}
-
 	r := &IssuersStorage{
-		bucket:      bkt,
+		bucket:      gcsClient.Bucket(bucket),
 		prefix:      staticct.IssuersPrefix,
 		contentType: staticct.IssuersContentType,
 	}

--- a/storage/gcp/issuers_test.go
+++ b/storage/gcp/issuers_test.go
@@ -54,30 +54,23 @@ func newTestStorage(t *testing.T, bucket string) *fakestorage.Server {
 
 func TestNewIssuerStorage(t *testing.T) {
 	tests := []struct {
-		name       string
-		wantBucket string
-		wantErr    bool
+		name   string
+		bucket string
 	}{
 		{
-			name:       "valid bucket",
-			wantBucket: testBucket,
-			wantErr:    false,
-		},
-		{
-			name:       "non-existing bucket",
-			wantBucket: "shovel",
-			wantErr:    true,
+			name:   "valid bucket",
+			bucket: testBucket,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			srv := newTestStorage(t, testBucket)
+			srv := newTestStorage(t, tt.bucket)
 			defer srv.Stop()
 
-			_, err := NewIssuerStorage(t.Context(), tt.wantBucket, srv.Client())
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewIssuerStorage() error = %v, wantErr %v", err, tt.wantErr)
+			_, err := NewIssuerStorage(t.Context(), tt.bucket, srv.Client())
+			if err != nil {
+				t.Errorf("NewIssuerStorage() error = %v", err)
 				return
 			}
 		})


### PR DESCRIPTION
Towards #212.

Essentially rolling back #669. This check that I added for GCS required another permission that TesseraCT didn't have. I then tried to check IAM permissions directly, but that doesn't work well with our storage test library. Operators will notice errors in TesseraCT's logs if it can't access storage properly.