### PR TITLE
Name buckets after origin for GCE deployment

### DIFF
--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
@@ -7,6 +7,7 @@ locals {
   docker_env                                 = local.env
   base_name                                  = include.root.locals.base_name
   origin                                     = "${local.base_name}${include.root.locals.origin_suffix}"
+  bucket_name                                = "${include.root.locals.project_id}-${local.base_name}-bucket"
   not_after_start                            = "2025-01-01T00:00:00Z"
   not_after_limit                            = "2025-07-01T00:00:00Z"
   server_docker_image                        = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
@@ -7,6 +7,7 @@ locals {
   docker_env                                 = local.env
   base_name                                  = include.root.locals.base_name
   origin                                     = "${local.base_name}${include.root.locals.origin_suffix}"
+  bucket_name                                = "${include.root.locals.project_id}-${local.base_name}-bucket"
   not_after_start                            = "2025-07-01T00:00:00Z"
   not_after_limit                            = "2026-01-01T00:00:00Z"
   server_docker_image                        = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"

--- a/deployment/live/gcp/static-ct-staging/logs/arche2026h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2026h1/terragrunt.hcl
@@ -7,6 +7,7 @@ locals {
   docker_env                                 = local.env
   base_name                                  = include.root.locals.base_name
   origin                                     = "${local.base_name}${include.root.locals.origin_suffix}"
+  bucket_name                                = "${include.root.locals.project_id}-${local.base_name}-bucket"
   not_after_start                            = "2026-01-01T00:00:00Z"
   not_after_limit                            = "2026-07-01T00:00:00Z"
   server_docker_image                        = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"

--- a/deployment/modules/gcp/storage/README.md
+++ b/deployment/modules/gcp/storage/README.md
@@ -1,0 +1,13 @@
+# Storage
+
+This module creates:
+ - a GCS bucket
+ - a Spanner database
+
+## GCS Bucket
+
+By default, this bucket will be called `{project_id}-{base_name}-bucket`.
+
+If you wish, you can name your bucket after a DNS name and use
+[domain-name bucket verification](https://docs.cloud.google.com/storage/docs/domain-name-verification)
+to demonstrate control of that domain.

--- a/deployment/modules/gcp/storage/main.tf
+++ b/deployment/modules/gcp/storage/main.tf
@@ -30,8 +30,14 @@ resource "google_project_service" "storage_googleapis_com" {
 
 # Buckets
 
+locals {
+  # If bucket_name is provided, use it. 
+  # Otherwise, default to the origin.
+  bucket_name = var.bucket_name != null ? var.bucket_name: "${var.project_id}-${var.base_name}-bucket"
+}
+
 resource "google_storage_bucket" "log_bucket" {
-  name                        = var.bucket_name
+  name                        = local.bucket_name
   location                    = var.location
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true

--- a/deployment/modules/gcp/storage/variables.tf
+++ b/deployment/modules/gcp/storage/variables.tf
@@ -3,14 +3,15 @@ variable "project_id" {
   type        = string
 }
 
-variable "bucket_name" {
-  description = "Name of the bucket to be created. SHOULD be the log's origin."
-  type        = string
-}
-
 variable "base_name" {
   description = "Base name to use when naming resources"
   type        = string
+}
+
+variable "bucket_name" {
+  description = "Name of the GCS bucket. Defaults to '{var.project_id}-{var.base_name}-bucket if unspecicfied"
+  type        = string
+  default     = null
 }
 
 variable "location" {

--- a/deployment/modules/gcp/tesseract/gce/main.tf
+++ b/deployment/modules/gcp/tesseract/gce/main.tf
@@ -2,11 +2,17 @@ terraform {
   backend "gcs" {}
 }
 
+locals {
+  # If bucket_name is provided, use it. 
+  # Otherwise, default to the origin.
+  bucket_name = var.bucket_name != null ? var.bucket_name: var.origin
+}
+
 module "storage" {
   source = "../../storage"
 
   project_id    = var.project_id
-  bucket_name   = "${var.base_name}${var.origin_suffix}"
+  bucket_name   = local.bucket_name
   base_name     = var.base_name
   location      = var.location
   ephemeral     = var.ephemeral

--- a/deployment/modules/gcp/tesseract/gce/variables.tf
+++ b/deployment/modules/gcp/tesseract/gce/variables.tf
@@ -13,6 +13,12 @@ variable "origin" {
   type        = string
 }
 
+variable "bucket_name" {
+  description = "Log bucket name. Defaults to `origin` if unspecified." 
+  type        = string
+  default     = null
+}
+
 variable "not_after_start" {
   description = "Start of the range of acceptable NotAfter values, inclusive. Leaving this empty implies no lower bound to the range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z."
   default     = ""


### PR DESCRIPTION
This names bucket after the origin by default for GCE deployments, leaving an escape hatch.
Other deployments (cloudrun, test) will use the legacy naming scheme `{project_id}-{base_name}-bucket`.