### PR TITLE
Add docs and warning around the use of latest key version alias

### DIFF
--- a/cmd/tesseract/gcp/README.md
+++ b/cmd/tesseract/gcp/README.md
@@ -12,6 +12,21 @@ You can find more information about TesseraCT in general in the
 [architecture design doc](/docs/architecture.md), and in TesseraCT's
 [configuration guide](../).
 
+## Keys and Secret Manager
+
+Log private and public keys are stored as secrets in Secret Manager, and the full secret version resource
+names passed to 
+`--signer_private_key_secret_name` and `--signer_public_key_secret_name` respectively.
+
+> [!WARNING]
+> While the `latest` version alias is supported, unless you are sure you know what you are doing, we 
+> strongly recommend the use of specific version IDs instead.
+>
+> Using `latest` will cause the log's key to be updated without warning if a new secret version is
+> created. Since CT for the WebPKI currently does not support log key rotation, other than through
+> retiring log shards and bringing up new ones, automatic rotation of the log key, inadvertant or 
+> otherwise, will therefore almost certainly result in an unplanned outage.
+
 ## Witnessing
 
 > [!WARNING]

--- a/cmd/tesseract/gcp/secret_manager.go
+++ b/cmd/tesseract/gcp/secret_manager.go
@@ -74,6 +74,10 @@ func NewSecretManagerSigner(ctx context.Context, publicKeySecretName, privateKey
 		}
 	}()
 
+	if strings.HasSuffix(privateKeySecretName, "/latest") {
+		klog.Warning("Secret version configured to use 'latest' alias; log key will change if a newer version is created.")
+	}
+
 	// Public Key
 	var publicKey crypto.PublicKey
 	pemBlock, err := secretPEM(ctx, client, publicKeySecretName)
@@ -128,9 +132,6 @@ func secret(ctx context.Context, client *secretmanager.Client, secretName string
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to access secret version: %w", err)
-	}
-	if resp.Name != secretName {
-		return nil, errors.New("request corrupted in-transit")
 	}
 	// Verify the data checksum.
 	crc32c := crc32.MakeTable(crc32.Castagnoli)


### PR DESCRIPTION
This PR makes it explicit that using the `latest` version alias for secret in Secret Manager is not recommended. 

Adds text to the GCP README explaining that keys are stored in Secret Manager, along with a warning about the `latest` alias.
Removes the unusual check that the requested key secret name is the same as the returned secret name, and replaces with a more explicit test for `latest` logging a warning if present.

Addresses #689