### PR TITLE
Use cosigv1-formatted vkey for TF witness

### DIFF
--- a/deployment/live/gcp/static-ct-staging/logs/witness.policy
+++ b/deployment/live/gcp/static-ct-staging/logs/witness.policy
@@ -6,7 +6,7 @@ witness mulvad-1 witness.stagemole.eu+67f7aea0+BEqSG3yu9YrmcM3BHvQYTxwFj3uSWakQe
 witness remora-1 remora.n621.de+da77ade7+BOvN63jn/bLvkieywe8R6UYAtVtNbZpXh34x7onlmtw2 https://remora.n621.de/
 witness rgdd-1 rgdd.se/poc-witness+db03732e+BCjJKlo6BU0xfIb8LutqerIFTWIXEA0L5n3tW3QyPFgG https://bastion.glasklar.is/70b861a010f25030de6ff6a5267e0b951e70c04b20ba4a3ce41e7fba7b9b7dfc
 witness smartit-1 witness1.smartit.nu/witness1+a48c820f+BPSFWg9G6KPiO7QPryYO5Xq4oYJJ+kAvLKLSimDhoxMO https://witness1.smartit.nu/witness1
-witness tf-1 transparency.dev/DEV:witness-little-garden+4b7fca75+AStusOxINQNUTN5Oj8HObRkh2yHf/MwYaGX4CPdiVEPM https://api.transparency.dev/dev/witness/little-garden 
+witness tf-1 transparency.dev/DEV:witness-little-garden+d8042a87+BCtusOxINQNUTN5Oj8HObRkh2yHf/MwYaGX4CPdiVEPM https://api.transparency.dev/dev/witness/little-garden 
 
 group dev_grp all geomys-dev-1 mulvad-1 remora-1 rgdd-1 smartit-1 tf-1
 


### PR DESCRIPTION
This PR updates the TF witness public vkey to one which explicitly specifies that it's an `0x04` Cosignature/v1 key. The public key material remains the same, though.

Since the Tessera witness support code will accept either `0x01` or `0x04` vkeys, this should be a `NOP`.