### PR TITLE
[POSIX] Env takes priority when configuring OTel attributes

### DIFF
--- a/cmd/tesseract/posix/otel.go
+++ b/cmd/tesseract/posix/otel.go
@@ -53,11 +53,11 @@ func initOTel(ctx context.Context, origin string) func(context.Context) {
 
 	resources, err := resource.New(ctx,
 		resource.WithTelemetrySDK(),
-		resource.WithFromEnv(), // unpacks OTEL_RESOURCE_ATTRIBUTES
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String(origin),
 			semconv.ServiceNamespaceKey.String("tesseract"),
 		),
+		resource.WithFromEnv(), // unpacks OTEL_RESOURCE_ATTRIBUTES
 	)
 	if err != nil {
 		klog.Exitf("Failed to detect resources: %v", err)


### PR DESCRIPTION
This makes POSIX OTel configuration order work the same way as GCP was changed to in #700.
