### PR TITLE
dot

### DIFF
--- a/deployment/modules/gcp/loadbalancer/external/main.tf
+++ b/deployment/modules/gcp/loadbalancer/external/main.tf
@@ -18,7 +18,7 @@ module "gce-lb-http" {
   ssl                   = true
   // Create one cert per log, wildcard certificates are not supported.
   // Put staging.ct.transparency.dev first for it be used as the Common Name.
-  managed_ssl_certificate_domains = concat(["staging.ct.transparency.dev"], [for name, v in var.logs: "${name}${v.submission_host_suffix}"])
+  managed_ssl_certificate_domains = concat(["staging.ct.transparency.dev"], [for name, v in var.logs: "${name}.${v.submission_host_suffix}"])
   random_certificate_suffix       = true
 
   // Firewalls are defined externally.
@@ -89,7 +89,7 @@ resource "google_compute_url_map" "url_map" {
     for_each = var.logs
     iterator = log
     content {
-      hosts        = ["${log.key}${log.value.submission_host_suffix}"]
+      hosts        = ["${log.key}.${log.value.submission_host_suffix}"]
       path_matcher = "${log.key}-path-matcher"
     }
   }


### PR DESCRIPTION
dot

I don't know what happened. I triple checked, the diff is now empty, for real:
```
┌[17:49][~/git/jj/tesseract] - (no branch)
└─> terragrunt plan --working-dir=deployment/live/gcp/static-ct-staging/loadbalancer
17:50:06.101 STDOUT tofu: Acquiring state lock. This may take a few moments...
17:50:08.379 STDOUT tofu: module.gce-lb-http.random_id.certificate[0]: Refreshing state... [id=KWXXug]
17:50:08.519 STDOUT tofu: module.gce-lb-http.google_compute_managed_ssl_certificate.default[0]: Refreshing state... [id=projects/static-ct-staging/global/sslCertificates/tesseract-lb-http-cert-2965d7ba]
17:50:08.519 STDOUT tofu: module.gce-lb-http.google_compute_global_address.default[0]: Refreshing state... [id=projects/static-ct-staging/global/addresses/tesseract-lb-http-address]
17:50:08.520 STDOUT tofu: module.gce-lb-http.google_compute_health_check.default["arche2026h1-backend"]: Refreshing state... [id=projects/static-ct-staging/global/healthChecks/tesseract-lb-http-hc-arche2026h1-backend]
17:50:08.521 STDOUT tofu: module.gce-lb-http.google_compute_health_check.default["arche2025h1-backend"]: Refreshing state... [id=projects/static-ct-staging/global/healthChecks/tesseract-lb-http-hc-arche2025h1-backend]
17:50:08.521 STDOUT tofu: module.gce-lb-http.google_compute_health_check.default["arche2025h2-backend"]: Refreshing state... [id=projects/static-ct-staging/global/healthChecks/tesseract-lb-http-hc-arche2025h2-backend]
17:50:08.522 STDOUT tofu: module.cloud_armor[0].google_compute_security_policy.policy: Refreshing state... [id=projects/static-ct-staging/global/securityPolicies/tesseract-security-policy]
17:50:08.955 STDOUT tofu: module.gce-lb-http.google_compute_backend_service.default["arche2025h2-backend"]: Refreshing state... [id=projects/static-ct-staging/global/backendServices/tesseract-lb-http-backend-arche2025h2-backend]
17:50:08.955 STDOUT tofu: module.gce-lb-http.google_compute_backend_service.default["arche2025h1-backend"]: Refreshing state... [id=projects/static-ct-staging/global/backendServices/tesseract-lb-http-backend-arche2025h1-backend]
17:50:08.955 STDOUT tofu: module.gce-lb-http.google_compute_backend_service.default["arche2026h1-backend"]: Refreshing state... [id=projects/static-ct-staging/global/backendServices/tesseract-lb-http-backend-arche2026h1-backend]
17:50:09.246 STDOUT tofu: google_compute_url_map.url_map: Refreshing state... [id=projects/static-ct-staging/global/urlMaps/tesseract-url-map]
17:50:09.604 STDOUT tofu: module.gce-lb-http.google_compute_target_http_proxy.default[0]: Refreshing state... [id=projects/static-ct-staging/global/targetHttpProxies/tesseract-lb-http-http-proxy]
17:50:09.604 STDOUT tofu: module.gce-lb-http.google_compute_target_https_proxy.default[0]: Refreshing state... [id=projects/static-ct-staging/global/targetHttpsProxies/tesseract-lb-http-https-proxy]
17:50:09.887 STDOUT tofu: module.gce-lb-http.google_compute_global_forwarding_rule.http[0]: Refreshing state... [id=projects/static-ct-staging/global/forwardingRules/tesseract-lb-http]
17:50:09.959 STDOUT tofu: module.gce-lb-http.google_compute_global_forwarding_rule.https[0]: Refreshing state... [id=projects/static-ct-staging/global/forwardingRules/tesseract-lb-http-https]
17:50:10.308 STDOUT tofu: No changes. Your infrastructure matches the configuration.
17:50:10.308 STDOUT tofu: OpenTofu has compared your real infrastructure against your configuration and
17:50:10.308 STDOUT tofu: found no differences, so no changes are needed.
```