### PR TITLE
Mark spans as errors in storage layer

### DIFF
--- a/internal/ct/handlers.go
+++ b/internal/ct/handlers.go
@@ -239,6 +239,7 @@ func (a appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		klog.Warningf("%s: %s handler error: %v", a.log.origin, a.name, err)
 		a.opts.sendHTTPError(w, statusCode, err)
+		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return
 	}


### PR DESCRIPTION
Previously the spans appeared as healthy, until they reached the tesseraCT.ServeHTTP.* handler. This change marks the failures lower down, and records the errors at the storage layer. As a bonus it also records the error at the top level when we have one. As a super-bonus, it fixes the case naming of the traces in the storage layer.
