### PR TITLE
Remove hardcoded domain

### DIFF
--- a/deployment/modules/gcp/loadbalancer/external/main.tf
+++ b/deployment/modules/gcp/loadbalancer/external/main.tf
@@ -16,9 +16,9 @@ module "gce-lb-http" {
   project               = var.project_id
   load_balancing_scheme = "EXTERNAL"
   ssl                   = true
-  // Create one cert per log, wildcard certificates are not supported.
-  // Put staging.ct.transparency.dev first for it be used as the Common Name.
-  managed_ssl_certificate_domains = concat(["staging.ct.transparency.dev"], [for name, v in var.logs: "${name}.${v.submission_host_suffix}"])
+  // Create a single certificate that covers all log domains, and all submission_host_suffixes.
+  // Wildcard certificates are not suported.
+  managed_ssl_certificate_domains = distinct(flatten([for name, v in var.logs: [v.submission_host_suffix, "${name}.${v.submission_host_suffix}"]]))
   random_certificate_suffix       = true
 
   // Firewalls are defined externally.


### PR DESCRIPTION
This PR removes `staging.ct.transparency.dev` from the module and uses whatever suffix logs use. It also corrects a comment that was not accurate.