### PR TITLE
Mark cloudrun traffic as internal

### DIFF
--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -35,6 +35,10 @@ resource "google_cloud_run_v2_service" "default" {
       min_instance_count = 2
     }
 
+    annotations = {
+      "run.googleapis.com/ingress" = "internal"
+    }
+
     containers {
       image = var.server_docker_image
       name  = "tesseract"


### PR DESCRIPTION
This should fix the CI test. Cloudrun services with `run.googleapis.com/ingress` set to `all` are not allowed anymore.