### PR TITLE
Mark cloudrun traffic as internal, again

### DIFF
--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -24,6 +24,7 @@ resource "google_cloud_run_v2_service" "default" {
   name         = var.base_name
   location     = var.location
   launch_stage = "GA"
+  ingress      = "INGRESS_TRAFFIC_ALL"
 
   template {
     service_account                  = "${local.cloudrun_service_account_id}@${var.project_id}.iam.gserviceaccount.com"
@@ -33,10 +34,6 @@ resource "google_cloud_run_v2_service" "default" {
     scaling {
       max_instance_count = 2
       min_instance_count = 2
-    }
-
-    annotations = {
-      "run.googleapis.com/ingress" = "internal"
     }
 
     containers {


### PR DESCRIPTION
`"Cloud Run API v2 does not support annotations with run.googleapis.com"`, let's use the new way.