### PR TITLE
Lower trace sampling ratio

### DIFF
--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
@@ -13,7 +13,7 @@ locals {
   server_docker_image                        = "tesseract-gcp:${include.root.locals.docker_container_tag}"
   docker_repo                                = "https://${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}"
   spanner_pu                                 = 500
-  trace_fraction                             = 0.1
+  trace_fraction                             = 0.002
   create_internal_load_balancer              = true
   public_bucket                              = true
   rate_limit_old_not_before                  = "28h:150"

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
@@ -13,7 +13,7 @@ locals {
   server_docker_image                        = "tesseract-gcp:${include.root.locals.docker_container_tag}"
   docker_repo                                = "https://${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}"
   spanner_pu                                 = 500
-  trace_fraction                             = 0.1
+  trace_fraction                             = 0.002
   create_internal_load_balancer              = true
   public_bucket                              = true
   machine_type                               = "n2-standard-8"

--- a/deployment/live/gcp/static-ct-staging/logs/arche2026h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2026h1/terragrunt.hcl
@@ -13,7 +13,7 @@ locals {
   server_docker_image                        = "tesseract-gcp:${include.root.locals.docker_container_tag}"
   docker_repo                                = "https://${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}"
   spanner_pu                                 = 500
-  trace_fraction                             = 0.1
+  trace_fraction                             = 0.002
   create_internal_load_balancer              = true
   public_bucket                              = true
   rate_limit_old_not_before                  = "28h:150"


### PR DESCRIPTION
This PR significantly reduces the volume of sampled traces on arche - currently we're way over-sampling and the vast majority are dropped at the Cloud Trace API level.