### PR TITLE
Prefix container name with forward slash in GCP logs entries

### DIFF
--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -44,7 +44,10 @@ locals {
     "-slog_level=-4",
     "-slog_to_cloud_api=true",
     "-otel_project_id=${var.project_id}",
-    "-container_name=${local.container_name}",
+    # This is used in GCP logs entries exported via the GCP logging API directly.
+    # Add a forward slash to match the container name of GCP log entries exported
+    # by Docker and the container agent directly. 
+    "-container_name=/${trimprefix(local.container_name, "/")}",
     "-image_name=${local.cached_docker_image}",
     "-http_endpoint=:80",
     "-bucket=${var.bucket}",


### PR DESCRIPTION
The `container_name` flag was introduced in #819 to fix #815. It allows have the container name in log entries exported to the GCP logging API directly, in the same way that we've got them in logging entries exported by klog via docker and the container agent.

Docker prefixes container names with a forward slash, and I couldn't find a way to remove this. Let's do the same with container names that we set manually to make sure that we can filter log entries efficiently.