### PR TITLE
Switch all klog to slog

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,24 @@
 version: "2"
+
 linters:
+  enable:
+    - depguard
+    - sloglint
   exclusions:
     paths:
       - internal/lax509
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: "k8s.io/klog/v2"
+              desc: "klog is forbidden, use log/slog instead"
+            - pkg: "k8s.io/klog"
+              desc: "klog is forbidden, use log/slog instead"
+    sloglint:
+      attr-only: true
+      context: all
 formatters:
   exclusions:
     paths:

--- a/cmd/experimental/fetch_roots/main.go
+++ b/cmd/experimental/fetch_roots/main.go
@@ -20,17 +20,18 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/transparency-dev/tesseract/internal/ccadb"
-	"k8s.io/klog/v2"
 )
 
 var (
 	url            = flag.String("url", "https://ccadb.my.salesforce-sites.com/ccadb/RootCACertificatesIncludedByRSReportCSV", "URL to fetch the CSV from.")
 	outputFilename = flag.String("output_filename", "roots.pem", "Path of the output file.")
+	slogLevel      = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
 )
 
 var (
@@ -39,27 +40,31 @@ var (
 )
 
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
-	roots, err := ccadb.Fetch(context.Background(), *url, allColumns)
+	ctx := context.Background()
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
+
+	roots, err := ccadb.Fetch(ctx, *url, allColumns)
 	if err != nil {
-		klog.Exitf("Error fetching roots: %s", err)
+		slog.ErrorContext(ctx, "Error fetching roots", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	outFile, err := createFile(*outputFilename)
 	if err != nil {
-		klog.Exitf("Error creating output file: %v", err)
+		slog.ErrorContext(ctx, "Error creating output file", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	defer func() {
 		if err := outFile.Close(); err != nil {
-			klog.Errorf("Error closing %q: %v", outFile.Name(), err)
+			slog.ErrorContext(ctx, "Error closing output file", slog.String("name", outFile.Name()), slog.Any("error", err))
 		}
 	}()
 
 	for _, row := range roots {
 		if len(row) != len(allColumns) {
-			klog.Errorf("Unexpected number of columns in row: got %d, want %d", len(row), len(allColumns))
+			slog.ErrorContext(ctx, "Unexpected number of columns in row", slog.Int("got", len(row)), slog.Int("want", len(allColumns)))
 		}
 
 		sha256 := formatBase64(string(row[2]), ":", 2)
@@ -68,11 +73,12 @@ func main() {
 			row[0], row[1], sha256, row[3])
 
 		if _, err := outFile.WriteString(output); err != nil {
-			klog.Exitf("Error writing to output file: %v", err)
+			slog.ErrorContext(ctx, "Error writing to output file", slog.Any("error", err))
+			os.Exit(1)
 		}
 	}
 
-	klog.Infof("Successfully extracted certificates to %s", *outputFilename)
+	slog.InfoContext(ctx, "Successfully extracted certificates", slog.String("output", *outputFilename))
 }
 
 // createFile creates a file at path p, and creates necessary parent directories.

--- a/cmd/experimental/migrate/gcp/main.go
+++ b/cmd/experimental/migrate/gcp/main.go
@@ -22,8 +22,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -33,7 +35,6 @@ import (
 	"github.com/transparency-dev/tessera/client"
 	"github.com/transparency-dev/tessera/storage/gcp"
 	gcp_as "github.com/transparency-dev/tessera/storage/gcp/antispam"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -48,13 +49,13 @@ var (
 )
 
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
 	ctx := context.Background()
 
 	srcURL, err := url.Parse(*sourceURL)
 	if err != nil {
-		klog.Exitf("Invalid --source_url %q: %v", *sourceURL, err)
+		slog.ErrorContext(ctx, "Invalid --source_url", slog.Any("arg", *sourceURL), slog.Any("error", err))
+		os.Exit(1)
 	}
 	hc := &http.Client{
 		Transport: &http.Transport{
@@ -69,29 +70,34 @@ func main() {
 	// When there's a Static CT client we can probably switch over to using it in here.
 	src, err := client.NewHTTPFetcher(srcURL, hc)
 	if err != nil {
-		klog.Exitf("Failed to create HTTP fetcher: %v", err)
+		slog.ErrorContext(ctx, "Failed to create HTTP fetcher", slog.Any("error", err))
+		os.Exit(1)
 	}
 	sourceCP, err := src.ReadCheckpoint(ctx)
 	if err != nil {
-		klog.Exitf("fetch initial source checkpoint: %v", err)
+		slog.ErrorContext(ctx, "fetch initial source checkpoint", slog.Any("error", err))
+		os.Exit(1)
 	}
 	// TODO(AlCutter): We should be properly verifying and opening the checkpoint here with the source log's
 	// public key.
 	bits := strings.Split(string(sourceCP), "\n")
 	sourceSize, err := strconv.ParseUint(bits[1], 10, 64)
 	if err != nil {
-		klog.Exitf("invalid CP size %q: %v", bits[1], err)
+		slog.ErrorContext(ctx, "invalid CP size", slog.Any("arg", bits[1]), slog.Any("error", err))
+		os.Exit(1)
 	}
 	sourceRoot, err := base64.StdEncoding.DecodeString(bits[2])
 	if err != nil {
-		klog.Exitf("invalid checkpoint roothash %q: %v", bits[2], err)
+		slog.ErrorContext(ctx, "invalid checkpoint roothash", slog.Any("arg", bits[2]), slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Create our Tessera storage backend:
 	gcpCfg := storageConfigFromFlags()
 	driver, err := gcp.New(ctx, gcpCfg)
 	if err != nil {
-		klog.Exitf("Failed to create new GCP storage driver: %v", err)
+		slog.ErrorContext(ctx, "Failed to create new GCP storage driver", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	opts := tessera.NewMigrationOptions().WithCTLayout()
@@ -107,19 +113,22 @@ func main() {
 		}
 		antispam, err = gcp_as.NewAntispam(ctx, fmt.Sprintf("%s-antispam", *spanner), as_opts)
 		if err != nil {
-			klog.Exitf("Failed to create new GCP antispam storage: %v", err)
+			slog.ErrorContext(ctx, "Failed to create new GCP antispam storage", slog.Any("error", err))
+		os.Exit(1)
 		}
 		opts.WithAntispam(antispam)
 	}
 
 	m, err := tessera.NewMigrationTarget(ctx, driver, opts)
 	if err != nil {
-		klog.Exitf("Failed to create MigrationTarget: %v", err)
+		slog.ErrorContext(ctx, "Failed to create MigrationTarget", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	readEntryBundle := readCTEntryBundle(*sourceURL, hc)
 	if err := m.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, readEntryBundle); err != nil {
-		klog.Exitf("Migrate failed: %v", err)
+		slog.ErrorContext(ctx, "Migrate failed", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// TODO(phbnf): This will need extending to identify and copy over the entries from the intermediate cert storage.
@@ -132,10 +141,12 @@ func main() {
 // provided via flags.
 func storageConfigFromFlags() gcp.Config {
 	if *bucket == "" {
-		klog.Exit("--bucket must be set")
+		slog.ErrorContext(context.Background(), "--bucket must be set")
+		os.Exit(1)
 	}
 	if *spanner == "" {
-		klog.Exit("--spanner must be set")
+		slog.ErrorContext(context.Background(), "--spanner must be set")
+		os.Exit(1)
 	}
 	return gcp.Config{
 		Bucket:  *bucket,
@@ -160,7 +171,7 @@ func readCTEntryBundle(srcURL string, hc *http.Client) func(ctx context.Context,
 		}
 		defer func() {
 			if err := rsp.Body.Close(); err != nil {
-				klog.Warningf("Failed to close response body: %v", err)
+				slog.WarnContext(ctx, "Failed to close response body", slog.Any("error", err))
 			}
 		}()
 		if rsp.StatusCode != http.StatusOK {

--- a/cmd/experimental/migrate/posix/main.go
+++ b/cmd/experimental/migrate/posix/main.go
@@ -22,8 +22,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -36,7 +38,6 @@ import (
 	"github.com/transparency-dev/tessera/client"
 	"github.com/transparency-dev/tessera/storage/posix"
 	tposix_as "github.com/transparency-dev/tessera/storage/posix/antispam"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -52,17 +53,18 @@ var (
 )
 
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
 	ctx := context.Background()
 
 	if *storageDir == "" {
-		klog.Exit("--storage_dir must be set")
+		slog.ErrorContext(ctx, "--storage_dir must be set")
+		os.Exit(1)
 	}
 
 	srcURL, err := url.Parse(*sourceURL)
 	if err != nil {
-		klog.Exitf("Invalid --source_url %q: %v", *sourceURL, err)
+		slog.ErrorContext(ctx, "Invalid --source_url", slog.Any("arg", *sourceURL), slog.Any("error", err))
+		os.Exit(1)
 	}
 	hc := &http.Client{
 		Transport: &http.Transport{
@@ -77,22 +79,26 @@ func main() {
 	// When there's a Static CT client we can probably switch over to using it in here.
 	src, err := client.NewHTTPFetcher(srcURL, hc)
 	if err != nil {
-		klog.Exitf("Failed to create HTTP fetcher: %v", err)
+		slog.ErrorContext(ctx, "Failed to create HTTP fetcher", slog.Any("error", err))
+		os.Exit(1)
 	}
 	sourceCP, err := src.ReadCheckpoint(ctx)
 	if err != nil {
-		klog.Exitf("fetch initial source checkpoint: %v", err)
+		slog.ErrorContext(ctx, "fetch initial source checkpoint", slog.Any("error", err))
+		os.Exit(1)
 	}
 	// TODO(AlCutter): We should be properly verifying and opening the checkpoint here with the source log's
 	// public key.
 	bits := strings.Split(string(sourceCP), "\n")
 	sourceSize, err := strconv.ParseUint(bits[1], 10, 64)
 	if err != nil {
-		klog.Exitf("invalid CP size %q: %v", bits[1], err)
+		slog.ErrorContext(ctx, "invalid CP size", slog.Any("arg", bits[1]), slog.Any("error", err))
+		os.Exit(1)
 	}
 	sourceRoot, err := base64.StdEncoding.DecodeString(bits[2])
 	if err != nil {
-		klog.Exitf("invalid checkpoint roothash %q: %v", bits[2], err)
+		slog.ErrorContext(ctx, "invalid checkpoint roothash", slog.Any("arg", bits[2]), slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Create our Tessera storage backend:
@@ -101,7 +107,8 @@ func main() {
 	}
 	driver, err := posix.New(ctx, cfg)
 	if err != nil {
-		klog.Exitf("Failed to create new POSIX storage driver: %v", err)
+		slog.ErrorContext(ctx, "Failed to create new POSIX storage driver", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	opts := tessera.NewMigrationOptions().WithCTLayout()
@@ -110,11 +117,13 @@ func main() {
 	if *persistentAntispam {
 		antispamIndexCacheBytes, error := humanize.ParseBytes(*antispamIndexCacheSize)
 		if error != nil {
-			klog.Exitf("Invalid antispam index cache size: %v", error)
+			slog.ErrorContext(ctx, "Invalid antispam index cache size", slog.Any("error", error))
+		os.Exit(1)
 		}
 		antispamBlockCacheBytes, error := humanize.ParseBytes(*antispamBlockCacheSize)
 		if error != nil {
-			klog.Exitf("Invalid antispam block cache size: %v", error)
+			slog.ErrorContext(ctx, "Invalid antispam block cache size", slog.Any("error", error))
+		os.Exit(1)
 		}
 		asOpts := tposix_as.AntispamOpts{
 			MaxBatchSize:       *antispamBatchSize,
@@ -127,19 +136,22 @@ func main() {
 		}
 		antispam, err = tposix_as.NewAntispam(ctx, filepath.Join(*storageDir, ".state", "antispam"), asOpts)
 		if err != nil {
-			klog.Exitf("Failed to create new POSIX antispam storage: %v", err)
+			slog.ErrorContext(ctx, "Failed to create new POSIX antispam storage", slog.Any("error", err))
+		os.Exit(1)
 		}
 		opts.WithAntispam(antispam)
 	}
 
 	m, err := tessera.NewMigrationTarget(ctx, driver, opts)
 	if err != nil {
-		klog.Exitf("Failed to create MigrationTarget: %v", err)
+		slog.ErrorContext(ctx, "Failed to create MigrationTarget", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	readEntryBundle := readCTEntryBundle(*sourceURL, hc)
 	if err := m.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, readEntryBundle); err != nil {
-		klog.Exitf("Migrate failed: %v", err)
+		slog.ErrorContext(ctx, "Migrate failed", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// TODO(phbnf): This will need extending to identify and copy over the entries from the intermediate cert storage.
@@ -165,7 +177,7 @@ func readCTEntryBundle(srcURL string, hc *http.Client) func(ctx context.Context,
 		}
 		defer func() {
 			if err := rsp.Body.Close(); err != nil {
-				klog.Warningf("Failed to close response body: %v", err)
+				slog.WarnContext(ctx, "Failed to close response body", slog.Any("error", err))
 			}
 		}()
 		if rsp.StatusCode != http.StatusOK {

--- a/cmd/fsck/internal/tui/app.go
+++ b/cmd/fsck/internal/tui/app.go
@@ -18,13 +18,12 @@ package tui
 import (
 	"bufio"
 	"context"
-	"flag"
 	"io"
+	"log/slog"
 	"time"
 
 	"github.com/transparency-dev/tessera/cmd/fsck/tui"
 	"github.com/transparency-dev/tessera/fsck"
-	"k8s.io/klog/v2"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
@@ -36,10 +35,8 @@ func RunApp(ctx context.Context, f *fsck.Fsck) error {
 	p := tea.NewProgram(m)
 
 	// Redirect logging so as to appear above the UI
-	_ = flag.Set("logtostderr", "false")
-	_ = flag.Set("alsologtostderr", "false")
 	r, w := io.Pipe()
-	klog.SetOutput(w)
+	slog.SetDefault(slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: slog.LevelInfo})))
 	go func() {
 		s := bufio.NewScanner(r)
 		for s.Scan() {

--- a/cmd/fsck/main.go
+++ b/cmd/fsck/main.go
@@ -23,8 +23,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -37,7 +39,6 @@ import (
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -49,6 +50,7 @@ var (
 	userAgentInfo    = flag.String("user_agent_info", "", "Optional string to append to the user agent (e.g. email address for Sunlight logs)")
 	bundleCompressed = flag.Bool("bundle_compressed", false, "Enable decompression of entry bundles, useful for Sunlight logs")
 	ui               = flag.Bool("ui", true, "Set to true to use a TUI to display progress, or false for logging")
+	slogLevel        = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
 )
 
 const (
@@ -61,8 +63,8 @@ type fetcher interface {
 }
 
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
 	ctx, cancel := context.WithCancel(context.Background())
 	src := fetcherFromFlags()
 	v := verifierFromFlags()
@@ -81,7 +83,7 @@ func main() {
 
 	if *ui {
 		if err := tui.RunApp(ctx, f); err != nil {
-			klog.Errorf("App exited: %v", err)
+			slog.ErrorContext(ctx, "App exited", slog.Any("error", err))
 		}
 		// User may have exited the UI, cancel the context to signal to everything else.
 		cancel()
@@ -91,16 +93,17 @@ func main() {
 			case <-ctx.Done():
 				return
 			case <-time.After(time.Second):
-				klog.V(1).Infof("Ranges:\n%s", f.Status())
+				slog.DebugContext(ctx, "Ranges", slog.Any("status", f.Status()))
 			}
 		}
 	}
 
 	if err := eg.Wait(); err != nil {
-		klog.Exitf("FAILED:\n%v", err)
+		slog.ErrorContext(ctx, "FAILED", slog.Any("error", err))
+		os.Exit(1)
 	}
 
-	klog.Info("OK")
+	slog.InfoContext(ctx, "OK")
 }
 
 // logStateCollector tracks state of the target log which needs to be later checked.
@@ -130,7 +133,7 @@ func (l *logStateCollector) Close() {
 // This is a long-running function, it will only exit once Close has been called, and all remaining fingerprints in the
 // issuersToCheck channel have been checked.
 func (l *logStateCollector) checkIssuersTask(ctx context.Context, readIssuer func(context.Context, []byte) ([]byte, error), N uint) error {
-	klog.Infof("Checking issuers CAS")
+	slog.InfoContext(ctx, "Checking issuers CAS")
 
 	// done will be closed when the function is ready to return
 	done := make(chan struct{})
@@ -156,11 +159,11 @@ func (l *logStateCollector) checkIssuersTask(ctx context.Context, readIssuer fun
 			defer wg.Done()
 			for fp := range l.issuersToCheck {
 				if _, err := readIssuer(ctx, fp); err != nil {
-					klog.Warningf("Couldn't fetch issuer FP %x: %v", fp, err)
+					slog.WarnContext(ctx, "Couldn't fetch issuer", slog.String("fp", fmt.Sprintf("%x", fp)), slog.Any("error", err))
 					errC <- fmt.Errorf("couldn't fetch issuer for %x: %v", fp, err)
 					continue
 				}
-				klog.V(2).Infof("Issuer FP %x is present", fp)
+				slog.DebugContext(ctx, "Issuer is present", slog.String("fp", fmt.Sprintf("%x", fp)))
 			}
 		}()
 	}
@@ -182,7 +185,7 @@ func (l *logStateCollector) addIssuers(fpRaw cryptobyte.String) {
 		fp, fpRaw = fpRaw[:32], fpRaw[32:]
 		_, existed := l.issuersSeen.LoadOrStore(string(fp), true)
 		if !existed {
-			klog.V(2).Infof("Found issuer FP %x", fp)
+			slog.DebugContext(context.Background(), "Found issuer", slog.String("fp", fmt.Sprintf("%x", fp)))
 			l.issuersToCheck <- fp
 		}
 	}
@@ -294,7 +297,8 @@ func copyUint24LengthPrefixed(from *cryptobyte.String, to *cryptobyte.Builder) b
 func fetcherFromFlags() fetcher {
 	logURL, err := url.Parse(*monitoringURL)
 	if err != nil {
-		klog.Exitf("Invalid --storage_url %q: %v", *monitoringURL, err)
+		slog.ErrorContext(context.Background(), "Invalid --storage_url", slog.String("url", *monitoringURL), slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	if logURL.Scheme == "file" {
@@ -314,7 +318,8 @@ func fetcherFromFlags() fetcher {
 	}
 	src, err := client.NewHTTPFetcher(logURL, hc)
 	if err != nil {
-		klog.Exitf("Failed to create HTTP fetcher: %v", err)
+		slog.ErrorContext(context.Background(), "Failed to create HTTP fetcher", slog.Any("error", err))
+		os.Exit(1)
 	}
 	src.EnableRetries(10)
 	ua := userAgent
@@ -329,31 +334,38 @@ func fetcherFromFlags() fetcher {
 }
 
 func verifierFromFlags() note.Verifier {
+	ctx := context.Background()
 	if *origin == "" {
-		klog.Exitf("Must provide the --origin flag")
+		slog.ErrorContext(ctx, "Must provide the --origin flag")
+		os.Exit(1)
 	}
 	if *pubKey == "" {
-		klog.Exitf("Must provide the --pub_key flag")
+		slog.ErrorContext(ctx, "Must provide the --pub_key flag")
+		os.Exit(1)
 	}
 	derBytes, err := base64.StdEncoding.DecodeString(*pubKey)
 	if err != nil {
-		klog.Exitf("Error decoding public key: %s", err)
+		slog.ErrorContext(ctx, "Error decoding public key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	pub, err := x509.ParsePKIXPublicKey(derBytes)
 	if err != nil {
-		klog.Exitf("Error parsing public key: %v", err)
+		slog.ErrorContext(ctx, "Error parsing public key", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	verifierKey, err := tdnote.RFC6962VerifierString(*origin, pub)
 	if err != nil {
-		klog.Exitf("Error creating RFC6962 verifier string: %v", err)
+		slog.ErrorContext(ctx, "Error creating RFC6962 verifier string", slog.Any("error", err))
+		os.Exit(1)
 	}
 	logSigV, err := tdnote.NewVerifier(verifierKey)
 	if err != nil {
-		klog.Exitf("Error creating verifier: %v", err)
+		slog.ErrorContext(ctx, "Error creating verifier", slog.Any("error", err))
+		os.Exit(1)
 	}
 
-	klog.Infof("Using verifier string: %v", verifierKey)
+	slog.InfoContext(ctx, "Using verifier", slog.String("key", verifierKey))
 
 	return logSigV
 }

--- a/cmd/tesseract/aws/README.md
+++ b/cmd/tesseract/aws/README.md
@@ -71,7 +71,7 @@ go run ./cmd/tesseract/aws \
   --signer_private_key_file=testlog-priv-key.pem \
   --s3_use_path_style=true \
   --roots_pem_file=internal/hammer/testdata/test_root_ca_cert.pem \
-  --v=1
+  --slog_level=-4
 ```
 
 A quick test to check that things have started ok can be made by looking for the
@@ -104,5 +104,5 @@ go run ./internal/hammer \
   --dup_chance=0.01 \
   --leaf_write_goal=100000 \
   --origin=${ORIGIN} \
-  --v=1
+  --slog_level=-4
 ```

--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -41,7 +42,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage/aws"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/mod/sumdb/note"
-	"k8s.io/klog/v2"
 )
 
 func init() {
@@ -106,13 +106,14 @@ var (
 	signerPublicKeyFile        = flag.String("signer_public_key_file", "", "Path to public key file for checkpoints and SCTs signer (alternative to secrets manager)")
 	signerPrivateKeyFile       = flag.String("signer_private_key_file", "", "Path to private key file for checkpoints and SCTs signer (alternative to secrets manager)")
 	usePathStyle               = flag.Bool("s3_use_path_style", false, "Whether to force the AWS S3 client to use path-style bucket references, probably only useful for on-prem deployments")
+	slogLevel                  = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
 )
 
 // nolint:staticcheck
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
 	ctx := context.Background()
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
 
 	var signer *ECDSAWithSHA256Signer
 	var err error
@@ -121,15 +122,18 @@ func main() {
 	if *signerPublicKeyFile != "" && *signerPrivateKeyFile != "" {
 		signer, err = NewLocalSigner(*signerPublicKeyFile, *signerPrivateKeyFile)
 		if err != nil {
-			klog.Exitf("Can't create local file signer: %v", err)
+			slog.ErrorContext(ctx, "Can't create local file signer", slog.Any("error", err))
+			os.Exit(1)
 		}
 	} else if *signerPublicKeySecretName != "" && *signerPrivateKeySecretName != "" {
 		signer, err = NewSecretsManagerSigner(ctx, *signerPublicKeySecretName, *signerPrivateKeySecretName)
 		if err != nil {
-			klog.Exitf("Can't create AWS Secrets Manager signer: %v", err)
+			slog.ErrorContext(ctx, "Can't create AWS Secrets Manager signer", slog.Any("error", err))
+			os.Exit(1)
 		}
 	} else {
-		klog.Exit("Must specify either local key files (--signer_public_key_file and --signer_private_key_file) or secrets manager keys (--signer_public_key_secret_name and --signer_private_key_secret_name)")
+		slog.ErrorContext(ctx, "Must specify either local key files (--signer_public_key_file and --signer_private_key_file) or secrets manager keys (--signer_public_key_secret_name and --signer_private_key_secret_name)")
+		os.Exit(1)
 	}
 
 	awsCfg := storageConfigFromFlags()
@@ -139,7 +143,8 @@ func main() {
 		S3Options: awsCfg.S3Options,
 	})
 	if err != nil {
-		klog.Exitf("failed to initialize S3 backup storage for remotely fetched roots: %v", err)
+		slog.ErrorContext(ctx, "failed to initialize S3 backup storage for remotely fetched roots", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	if len(rootsRemoteFetchURLs) == 0 {
@@ -161,7 +166,7 @@ func main() {
 		RejectRoots:              rootsRejectFingerprints,
 	}
 	if *acceptSHA1 {
-		klog.Info(`**** WARNING **** This server will accept chains signed
+		slog.InfoContext(ctx, `**** WARNING **** This server will accept chains signed
 using SHA-1 based algorithms. This feature is available to allow chains
 submitted by Chrome's Merge Delay Monitor Root for the time being, but will
 eventually go away. See /internal/lax509/README.md for more information.`)
@@ -174,11 +179,11 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newAWSStorageFunc(awsCfg), *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
-		klog.Exitf("Can't initialize CT HTTP Server: %v", err)
+		slog.ErrorContext(ctx, "Can't initialize CT HTTP Server", slog.Any("error", err))
+		os.Exit(1)
 	}
 
-	klog.CopyStandardLogTo("WARNING")
-	klog.Info("**** CT HTTP Server Starting ****")
+	slog.InfoContext(ctx, "**** CT HTTP Server Starting ****")
 	http.Handle("/", otelhttp.NewHandler(logHandler, "/"))
 
 	// Bring up the HTTP server and serve until we get a signal not to.
@@ -196,20 +201,19 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 		// TODO(phboneff): maybe wait for the sequencer queue to be empty?
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 		defer cancel()
-		klog.Info("Shutting down HTTP server...")
+		slog.InfoContext(ctx, "Shutting down HTTP server...")
 		if err := srv.Shutdown(ctx); err != nil {
-			klog.Errorf("srv.Shutdown(): %v", err)
+			slog.ErrorContext(ctx, "srv.Shutdown()", slog.Any("error", err))
 		}
-		klog.Info("HTTP server shutdown")
+		slog.InfoContext(ctx, "HTTP server shutdown")
 	})
 
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-		klog.Warningf("Server exited: %v", err)
+		slog.WarnContext(ctx, "Server exited", slog.Any("error", err))
 	}
 	// Wait will only block if the function passed to awaitSignal was called,
 	// in which case it'll block until the HTTP server has gracefully shutdown
 	shutdownWG.Wait()
-	klog.Flush()
 }
 
 // awaitSignal waits for standard termination signals, then runs the given
@@ -221,8 +225,7 @@ func awaitSignal(doneFn func()) {
 
 	// Now block main and wait for a signal
 	sig := <-sigs
-	klog.Warningf("Signal received: %v", sig)
-	klog.Flush()
+	slog.WarnContext(context.Background(), "Signal received", slog.Any("signal", sig))
 
 	doneFn()
 }
@@ -343,23 +346,29 @@ func (ms *multiStringFlag) Set(w string) error {
 // provided via flags.
 func storageConfigFromFlags() taws.Config {
 	if *bucket == "" {
-		klog.Exit("--bucket must be set")
+		slog.ErrorContext(context.Background(), "--bucket must be set")
+		os.Exit(1)
 	}
 	if *dbName == "" {
-		klog.Exit("--db_name must be set")
+		slog.ErrorContext(context.Background(), "--db_name must be set")
+		os.Exit(1)
 	}
 	if *dbHost == "" {
-		klog.Exit("--db_host must be set")
+		slog.ErrorContext(context.Background(), "--db_host must be set")
+		os.Exit(1)
 	}
 	if *dbPort == 0 {
-		klog.Exit("--db_port must be set")
+		slog.ErrorContext(context.Background(), "--db_port must be set")
+		os.Exit(1)
 	}
 	if *dbUser == "" {
-		klog.Exit("--db_user must be set")
+		slog.ErrorContext(context.Background(), "--db_user must be set")
+		os.Exit(1)
 	}
 	// Empty password isn't an option with AuroraDB MySQL.
 	if *dbPassword == "" {
-		klog.Exit("--db_password must be set")
+		slog.ErrorContext(context.Background(), "--db_password must be set")
+		os.Exit(1)
 	}
 
 	c := mysql.Config{
@@ -397,20 +406,25 @@ func storageConfigFromFlags() taws.Config {
 
 func antispamMySQLConfig() *mysql.Config {
 	if *antispamDBName == "" {
-		klog.Exit("--antispam_db_name must be set")
+		slog.ErrorContext(context.Background(), "--antispam_db_name must be set")
+		os.Exit(1)
 	}
 	if *dbHost == "" {
-		klog.Exit("--db_host must be set")
+		slog.ErrorContext(context.Background(), "--db_host must be set")
+		os.Exit(1)
 	}
 	if *dbPort == 0 {
-		klog.Exit("--db_port must be set")
+		slog.ErrorContext(context.Background(), "--db_port must be set")
+		os.Exit(1)
 	}
 	if *dbUser == "" {
-		klog.Exit("--db_user must be set")
+		slog.ErrorContext(context.Background(), "--db_user must be set")
+		os.Exit(1)
 	}
 	// Empty password isn't an option with AuroraDB MySQL.
 	if *dbPassword == "" {
-		klog.Exit("--db_password must be set")
+		slog.ErrorContext(context.Background(), "--db_password must be set")
+		os.Exit(1)
 	}
 
 	return &mysql.Config{
@@ -430,15 +444,18 @@ func notBeforeRLFromFlags() *tesseract.NotBeforeRL {
 	}
 	bits := strings.Split(*notBeforeRL, ":")
 	if len(bits) != 2 {
-		klog.Exitf("Invalid format for --rate_limit_old_not_before flag")
+		slog.ErrorContext(context.Background(), "Invalid format for --rate_limit_old_not_before flag")
+		os.Exit(1)
 	}
 	a, err := time.ParseDuration(bits[0])
 	if err != nil {
-		klog.Exitf("Invalid age passed to --rate_limit_old_not_before flag %q: %v", bits[0], err)
+		slog.ErrorContext(context.Background(), "Invalid age passed to --rate_limit_old_not_before flag", slog.String("age", bits[0]), slog.Any("error", err))
+		os.Exit(1)
 	}
 	l, err := strconv.ParseFloat(bits[1], 64)
 	if err != nil {
-		klog.Exitf("Invalid rate limit passed to --rate_limit_old_not_before %q: %v", bits[1], err)
+		slog.ErrorContext(context.Background(), "Invalid rate limit passed to --rate_limit_old_not_before", slog.String("limit", bits[1]), slog.Any("error", err))
+		os.Exit(1)
 	}
 	return &tesseract.NotBeforeRL{AgeThreshold: a, RateLimit: l}
 }

--- a/cmd/tesseract/gcp/README.md
+++ b/cmd/tesseract/gcp/README.md
@@ -47,18 +47,8 @@ the format described by https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/mai
 
 ## Logging
 
-TesseraCT on GCP uses two logging systems as it transitions to structured logging:
-
-### Standard `klog` (Legacy)
-Many internal libraries and older code use `klog`. 
-- **Routing**: `klog` is configured to write to `stderr` (`-logtostderr`). When running in GCE/COS, the Docker daemon intercepts `stderr` because it is configured with `--log-driver=gcplogs`. 
-- **Expected Fields**: Because Docker's `gcplogs` driver handles the transmission, it automatically decorates logs with:
-  - `container`: name, id, image name, etc.
-  - `instance`: VM name, id, zone.
-
-### Structured `slog` (Recommended)
-Newer code and the main server logs use `log/slog`.
-- **Routing**: By default, `slog` bakes OpenTelemetry trace context and exports logs **directly to the Cloud Logging API** (bypassing `stderr`). 
+TesseraCT uses Go's `log/slog` for structured logging.
+- **Routing**: By default, `slog` bakes OpenTelemetry trace context and exports logs **directly to the Cloud Logging API** (bypassing `stderr`). The cut-off level can be tuned via `--slog_level` (default `0` = INFO; `-4` = DEBUG).
 - **Expected Fields**: Because it bypasses `stderr` and the Docker `gcplogs` driver, it does not get automatic container/instance decoration by Docker. Instead, at startup, TesseraCT queries the GCE Metadata Server and reads flags to manually bake these fields into the default `slog` logger. You can expect:
   - `message`
   - `severity`

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -124,16 +124,15 @@ func main() {
 	flag.Parse()
 	ctx := context.Background()
 
-	cleanup := initLogging(ctx)
-	defer cleanup()
+	initLogging(ctx)
+	defer flushLogs()
 
 	shutdownOTel := initOTel(ctx, *traceFraction, *origin, *otelProjectID)
 	defer shutdownOTel(ctx)
 
 	signer, err := NewSecretManagerSigner(ctx, *signerPublicKeySecretName, *signerPrivateKeySecretName)
 	if err != nil {
-		slog.ErrorContext(ctx, "Can't create secret manager signer", slog.Any("error", err))
-		os.Exit(1)
+		fatal(ctx, "Can't create secret manager signer", slog.Any("error", err))
 	}
 
 	hc := &http.Client{
@@ -147,13 +146,11 @@ func main() {
 
 	gcsClient, err := gcs.NewGRPCClient(ctx, option.WithGRPCConnectionPool(*gcsConnections))
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create gRPC GCS client", slog.Any("error", err))
-		os.Exit(1)
+		fatal(ctx, "Failed to create gRPC GCS client", slog.Any("error", err))
 	}
 	fetchedRootsBackupStorage, err := gcp.NewRootsStorage(ctx, *bucket, gcsClient)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to initialize GCS backup storage for remotely fetched roots", slog.Any("error", err))
-		os.Exit(1)
+		fatal(ctx, "failed to initialize GCS backup storage for remotely fetched roots", slog.Any("error", err))
 	}
 
 	if len(rootsRemoteFetchURLs) == 0 {
@@ -188,8 +185,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newGCPStorage(gcsClient, hc), *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
-		slog.ErrorContext(ctx, "Can't initialize CT HTTP Server", slog.Any("error", err))
-		os.Exit(1)
+		fatal(ctx, "Can't initialize CT HTTP Server", slog.Any("error", err))
 	}
 
 	slog.InfoContext(ctx, "**** CT HTTP Server Starting ****")
@@ -372,23 +368,40 @@ func notBeforeRLFromFlags() *tesseract.NotBeforeRL {
 	}
 	bits := strings.Split(*notBeforeRL, ":")
 	if len(bits) != 2 {
-		slog.ErrorContext(context.Background(), "Invalid format for --rate_limit_old_not_before flag")
-		os.Exit(1)
+		fatal(context.Background(), "Invalid format for --rate_limit_old_not_before flag")
 	}
 	a, err := time.ParseDuration(bits[0])
 	if err != nil {
-		slog.ErrorContext(context.Background(), "Invalid age passed to --rate_limit_old_not_before flag", slog.String("age", bits[0]), slog.Any("error", err))
-		os.Exit(1)
+		fatal(context.Background(), "Invalid age passed to --rate_limit_old_not_before flag", slog.String("age", bits[0]), slog.Any("error", err))
 	}
 	l, err := strconv.ParseFloat(bits[1], 64)
 	if err != nil {
-		slog.ErrorContext(context.Background(), "Invalid rate limit passed to --rate_limit_old_not_before", slog.String("limit", bits[1]), slog.Any("error", err))
-		os.Exit(1)
+		fatal(context.Background(), "Invalid rate limit passed to --rate_limit_old_not_before", slog.String("limit", bits[1]), slog.Any("error", err))
 	}
 	return &tesseract.NotBeforeRL{AgeThreshold: a, RateLimit: l}
 }
 
-func initLogging(ctx context.Context) func() {
+// logFlushers holds cleanup callbacks (e.g. closing the Cloud Logging client)
+// that must run before the process exits to drain any buffered async log
+// entries. flushLogs runs them; fatal logs an error, flushes, then exits 1.
+var logFlushers []func()
+
+func flushLogs() {
+	for _, f := range logFlushers {
+		f()
+	}
+}
+
+// fatal logs msg at Error level, flushes any buffered log handlers, and exits
+// with status 1. Use this in place of slog.ErrorContext + os.Exit(1) so async
+// handlers (notably the GCP Cloud Logging exporter) get a chance to drain.
+func fatal(ctx context.Context, msg string, attrs ...any) {
+	slog.ErrorContext(ctx, msg, attrs...)
+	flushLogs()
+	os.Exit(1)
+}
+
+func initLogging(ctx context.Context) {
 	var staticAttrs []any
 	containerMap := map[string]string{}
 	if *containerName != "" {
@@ -433,19 +446,16 @@ func initLogging(ctx context.Context) func() {
 		}))
 	}
 
-	var cleanup []func()
 	if *slogToCloudAPI {
 		if *otelProjectID == "" {
-			slog.ErrorContext(ctx, "--otel_project_id is required when --slog_to_cloud_api is true")
-			os.Exit(1)
+			// Cloud Logging client isn't set up yet, so fatal here is equivalent to slog+os.Exit.
+			fatal(ctx, "--otel_project_id is required when --slog_to_cloud_api is true")
 		}
-		var err error
 		loggingClient, err := logging.NewClient(ctx, "projects/"+*otelProjectID)
 		if err != nil {
-			slog.ErrorContext(ctx, "Failed to create Cloud Logging client", slog.Any("error", err))
-			os.Exit(1)
+			fatal(ctx, "Failed to create Cloud Logging client", slog.Any("error", err))
 		}
-		cleanup = append(cleanup, func() {
+		logFlushers = append(logFlushers, func() {
 			if err := loggingClient.Close(); err != nil {
 				slog.ErrorContext(ctx, "Failed to close Cloud Logging client", slog.Any("error", err))
 			}
@@ -459,11 +469,5 @@ func initLogging(ctx context.Context) func() {
 			l = l.With(staticAttrs...)
 		}
 		slog.SetDefault(l)
-	}
-
-	return func() {
-		for _, f := range cleanup {
-			f()
-		}
 	}
 }

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -34,7 +34,6 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/logging"
-	"k8s.io/klog/v2"
 
 	"cloud.google.com/go/spanner"
 	gcs "cloud.google.com/go/storage"
@@ -122,7 +121,6 @@ var (
 
 // nolint:staticcheck
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
 	ctx := context.Background()
 
@@ -134,7 +132,8 @@ func main() {
 
 	signer, err := NewSecretManagerSigner(ctx, *signerPublicKeySecretName, *signerPrivateKeySecretName)
 	if err != nil {
-		klog.Exitf("Can't create secret manager signer: %v", err)
+		slog.ErrorContext(ctx, "Can't create secret manager signer", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	hc := &http.Client{
@@ -148,11 +147,13 @@ func main() {
 
 	gcsClient, err := gcs.NewGRPCClient(ctx, option.WithGRPCConnectionPool(*gcsConnections))
 	if err != nil {
-		klog.Exitf("Failed to create gRPC GCS client: %v", err)
+		slog.ErrorContext(ctx, "Failed to create gRPC GCS client", slog.Any("error", err))
+		os.Exit(1)
 	}
 	fetchedRootsBackupStorage, err := gcp.NewRootsStorage(ctx, *bucket, gcsClient)
 	if err != nil {
-		klog.Exitf("failed to initialize GCS backup storage for remotely fetched roots: %v", err)
+		slog.ErrorContext(ctx, "failed to initialize GCS backup storage for remotely fetched roots", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	if len(rootsRemoteFetchURLs) == 0 {
@@ -174,7 +175,7 @@ func main() {
 		RejectRoots:              rootsRejectFingerprints,
 	}
 	if *acceptSHA1 {
-		klog.Info(`**** WARNING **** This server will accept chains signed
+		slog.InfoContext(ctx, `**** WARNING **** This server will accept chains signed
 using SHA-1 based algorithms. This feature is available to allow chains
 submitted by Chrome's Merge Delay Monitor Root for the time being, but will
 eventually go away. See /internal/lax509/README.md for more information.`)
@@ -187,11 +188,11 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newGCPStorage(gcsClient, hc), *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
-		klog.Exitf("Can't initialize CT HTTP Server: %v", err)
+		slog.ErrorContext(ctx, "Can't initialize CT HTTP Server", slog.Any("error", err))
+		os.Exit(1)
 	}
 
-	klog.CopyStandardLogTo("WARNING")
-	klog.Info("**** CT HTTP Server Starting ****")
+	slog.InfoContext(ctx, "**** CT HTTP Server Starting ****")
 	http.Handle("/", otelhttp.NewHandler(logHandler, "/"))
 
 	// Bring up the HTTP server and serve until we get a signal not to.
@@ -209,20 +210,19 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 		// TODO(phboneff): maybe wait for the sequencer queue to be empty?
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 		defer cancel()
-		klog.Info("Shutting down HTTP server...")
+		slog.InfoContext(ctx, "Shutting down HTTP server...")
 		if err := srv.Shutdown(ctx); err != nil {
-			klog.Errorf("srv.Shutdown(): %v", err)
+			slog.ErrorContext(ctx, "srv.Shutdown()", slog.Any("error", err))
 		}
-		klog.Info("HTTP server shutdown")
+		slog.InfoContext(ctx, "HTTP server shutdown")
 	})
 
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-		klog.Warningf("Server exited: %v", err)
+		slog.WarnContext(ctx, "Server exited", slog.Any("error", err))
 	}
 	// Wait will only block if the function passed to awaitSignal was called,
 	// in which case it'll block until the HTTP server has gracefully shutdown
 	shutdownWG.Wait()
-	klog.Flush()
 }
 
 // awaitSignal waits for standard termination signals, then runs the given
@@ -234,8 +234,7 @@ func awaitSignal(doneFn func()) {
 
 	// Now block main and wait for a signal
 	sig := <-sigs
-	klog.Warningf("Signal received: %v", sig)
-	klog.Flush()
+	slog.WarnContext(context.Background(), "Signal received", slog.Any("signal", sig))
 
 	doneFn()
 }
@@ -373,15 +372,18 @@ func notBeforeRLFromFlags() *tesseract.NotBeforeRL {
 	}
 	bits := strings.Split(*notBeforeRL, ":")
 	if len(bits) != 2 {
-		klog.Exitf("Invalid format for --rate_limit_old_not_before flag")
+		slog.ErrorContext(context.Background(), "Invalid format for --rate_limit_old_not_before flag")
+		os.Exit(1)
 	}
 	a, err := time.ParseDuration(bits[0])
 	if err != nil {
-		klog.Exitf("Invalid age passed to --rate_limit_old_not_before flag %q: %v", bits[0], err)
+		slog.ErrorContext(context.Background(), "Invalid age passed to --rate_limit_old_not_before flag", slog.String("age", bits[0]), slog.Any("error", err))
+		os.Exit(1)
 	}
 	l, err := strconv.ParseFloat(bits[1], 64)
 	if err != nil {
-		klog.Exitf("Invalid rate limit passed to --rate_limit_old_not_before %q: %v", bits[1], err)
+		slog.ErrorContext(context.Background(), "Invalid rate limit passed to --rate_limit_old_not_before", slog.String("limit", bits[1]), slog.Any("error", err))
+		os.Exit(1)
 	}
 	return &tesseract.NotBeforeRL{AgeThreshold: a, RateLimit: l}
 }
@@ -434,16 +436,18 @@ func initLogging(ctx context.Context) func() {
 	var cleanup []func()
 	if *slogToCloudAPI {
 		if *otelProjectID == "" {
-			klog.Exitf("--otel_project_id is required when --slog_to_cloud_api is true")
+			slog.ErrorContext(ctx, "--otel_project_id is required when --slog_to_cloud_api is true")
+			os.Exit(1)
 		}
 		var err error
 		loggingClient, err := logging.NewClient(ctx, "projects/"+*otelProjectID)
 		if err != nil {
-			klog.Exitf("Failed to create Cloud Logging client: %v", err)
+			slog.ErrorContext(ctx, "Failed to create Cloud Logging client", slog.Any("error", err))
+			os.Exit(1)
 		}
 		cleanup = append(cleanup, func() {
 			if err := loggingClient.Close(); err != nil {
-				klog.Errorf("Failed to close Cloud Logging client: %v", err)
+				slog.ErrorContext(ctx, "Failed to close Cloud Logging client", slog.Any("error", err))
 			}
 		})
 		loggingHandlers = append(loggingHandlers, logger.NewExporter(loggingClient.Logger("tesseract"), slog.Level(*slogLevel)))

--- a/cmd/tesseract/gcp/otel.go
+++ b/cmd/tesseract/gcp/otel.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 
 	t_otel "github.com/transparency-dev/tesseract/internal/otel"
@@ -32,7 +33,6 @@ import (
 	texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 
 	"github.com/google/uuid"
-	"k8s.io/klog/v2"
 )
 
 // initOTel initialises the open telemetry support for metrics and tracing.
@@ -50,13 +50,13 @@ func initOTel(ctx context.Context, traceFraction float64, origin string, project
 		}
 		shutdownFuncs = nil
 		if err != nil {
-			klog.Errorf("OTel shutdown: %v", err)
+			slog.ErrorContext(ctx, "OTel shutdown", slog.Any("error", err))
 		}
 	}
 
 	instanceID, err := os.Hostname()
 	if err != nil {
-		klog.Errorf("os.Hostname() failed, setting OTel service instance ID to UUID. Error: %v", err)
+		slog.ErrorContext(ctx, "os.Hostname() failed, setting OTel service instance ID to UUID", slog.Any("error", err))
 		instanceID = uuid.NewString()
 	}
 	resources, err := resource.New(ctx,
@@ -71,7 +71,8 @@ func initOTel(ctx context.Context, traceFraction float64, origin string, project
 		resource.WithDetectors(gcp.NewDetector()),
 	)
 	if err != nil {
-		klog.Exitf("Failed to detect resources: %v", err)
+		slog.ErrorContext(ctx, "Failed to detect resources", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	mopts := []mexporter.Option{}
@@ -80,7 +81,8 @@ func initOTel(ctx context.Context, traceFraction float64, origin string, project
 	}
 	me, err := mexporter.New(mopts...)
 	if err != nil {
-		klog.Exitf("Failed to create metric exporter: %v", err)
+		slog.ErrorContext(ctx, "Failed to create metric exporter", slog.Any("error", err))
+		os.Exit(1)
 		return nil
 	}
 	// initialize a MeterProvider that periodically exports to the GCP exporter.
@@ -97,7 +99,8 @@ func initOTel(ctx context.Context, traceFraction float64, origin string, project
 	}
 	te, err := texporter.New(topts...)
 	if err != nil {
-		klog.Exitf("Failed to create trace exporter: %v", err)
+		slog.ErrorContext(ctx, "Failed to create trace exporter", slog.Any("error", err))
+		os.Exit(1)
 		return nil
 	}
 	// initialize a TracerProvier that periodically exports to the GCP exporter.
@@ -112,7 +115,8 @@ func initOTel(ctx context.Context, traceFraction float64, origin string, project
 	// 	https://github.com/open-telemetry/opentelemetry-go-contrib
 
 	if err := runtime.Start(runtime.WithMeterProvider(mp)); err != nil {
-		klog.Exitf("Failed to start exporting Go runtime metrics: %v", err)
+		slog.ErrorContext(ctx, "Failed to start exporting Go runtime metrics", slog.Any("error", err))
+		os.Exit(1)
 	}
 	return shutdown
 }

--- a/cmd/tesseract/gcp/otel.go
+++ b/cmd/tesseract/gcp/otel.go
@@ -71,8 +71,7 @@ func initOTel(ctx context.Context, traceFraction float64, origin string, project
 		resource.WithDetectors(gcp.NewDetector()),
 	)
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to detect resources", slog.Any("error", err))
-		os.Exit(1)
+		fatal(ctx, "Failed to detect resources", slog.Any("error", err))
 	}
 
 	mopts := []mexporter.Option{}
@@ -81,8 +80,7 @@ func initOTel(ctx context.Context, traceFraction float64, origin string, project
 	}
 	me, err := mexporter.New(mopts...)
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create metric exporter", slog.Any("error", err))
-		os.Exit(1)
+		fatal(ctx, "Failed to create metric exporter", slog.Any("error", err))
 		return nil
 	}
 	// initialize a MeterProvider that periodically exports to the GCP exporter.
@@ -99,8 +97,7 @@ func initOTel(ctx context.Context, traceFraction float64, origin string, project
 	}
 	te, err := texporter.New(topts...)
 	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create trace exporter", slog.Any("error", err))
-		os.Exit(1)
+		fatal(ctx, "Failed to create trace exporter", slog.Any("error", err))
 		return nil
 	}
 	// initialize a TracerProvier that periodically exports to the GCP exporter.
@@ -115,8 +112,7 @@ func initOTel(ctx context.Context, traceFraction float64, origin string, project
 	// 	https://github.com/open-telemetry/opentelemetry-go-contrib
 
 	if err := runtime.Start(runtime.WithMeterProvider(mp)); err != nil {
-		slog.ErrorContext(ctx, "Failed to start exporting Go runtime metrics", slog.Any("error", err))
-		os.Exit(1)
+		fatal(ctx, "Failed to start exporting Go runtime metrics", slog.Any("error", err))
 	}
 	return shutdown
 }

--- a/cmd/tesseract/gcp/secret_manager.go
+++ b/cmd/tesseract/gcp/secret_manager.go
@@ -24,12 +24,12 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"log/slog"
 	"strings"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"golang.org/x/mod/sumdb/note"
-	"k8s.io/klog/v2"
 )
 
 // TODO: Move ECDSAWithSHA256Signer to internal signer package.
@@ -70,12 +70,12 @@ func NewSecretManagerSigner(ctx context.Context, publicKeySecretName, privateKey
 	}
 	defer func() {
 		if err := client.Close(); err != nil {
-			klog.Warningf("Failed to close secret manager client: %v", err)
+			slog.WarnContext(ctx, "Failed to close secret manager client", slog.Any("error", err))
 		}
 	}()
 
 	if strings.HasSuffix(privateKeySecretName, "/latest") {
-		klog.Warning("Secret version configured to use 'latest' alias; log key will change if a newer version is created.")
+		slog.WarnContext(ctx, "Secret version configured to use 'latest' alias; log key will change if a newer version is created.")
 	}
 
 	// Public Key
@@ -169,7 +169,7 @@ func NewSecretManagerNoteSigner(ctx context.Context, privateKeySecretName string
 	}
 	defer func() {
 		if err := client.Close(); err != nil {
-			klog.Warningf("Failed to close secret manager client: %v", err)
+			slog.WarnContext(ctx, "Failed to close secret manager client", slog.Any("error", err))
 		}
 	}()
 

--- a/cmd/tesseract/posix/README.md
+++ b/cmd/tesseract/posix/README.md
@@ -69,7 +69,7 @@ go run ./cmd/tesseract/posix/ \
   --origin=example.com/test-ecdsa \
   --storage_dir=/tmp/ecdsa_log \
   --roots_pem_file=deployment/live/gcp/static-ct-staging/logs/arche2025h1/roots.pem \
-  --v=1
+  --slog_level=-4
 ```
 
 The server should now be listening on port `:6962` to handle the _submission URLs_ from
@@ -86,7 +86,7 @@ go run github.com/google/certificate-transparency-go/preload/preloader@master \
   --start_index=130000 \
   --parallel_fetch=2 \
   --parallel_submit=512 \
-  --v=1
+  --slog_level=-4
 ```
 
 Note that running this command a second time may show a lot of errors with

--- a/cmd/tesseract/posix/ci/docker-compose.yml
+++ b/cmd/tesseract/posix/ci/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     command:
       - "--http_endpoint=0.0.0.0:6962"
       - "--storage_dir=/testlog"
-      - "--v=1"
+      - "--slog_level=-4"
       - "--roots_pem_file=/testdata/test_root_ca_cert.pem"
       - "--origin=example.com/test-ecdsa"
       - "--private_key=/testlog/test-ecdsa-priv.pem"

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log/slog"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -43,7 +44,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-	"k8s.io/klog/v2"
 
 	_ "expvar" // Registers /debug/vars, with BadgerDB metrics.
 )
@@ -108,12 +108,13 @@ var (
 	storageDir    = flag.String("storage_dir", "", "Path to root of log storage.")
 	privKeyFile   = flag.String("private_key", "", "Location of private key file. If unset, uses the contents of the LOG_PRIVATE_KEY environment variable.")
 	traceFraction = flag.Float64("trace_fraction", 0, "Fraction of open-telemetry span traces to sample")
+	slogLevel     = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
 )
 
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
 	ctx := context.Background()
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
 
 	shutdownOTel := initOTel(ctx, *traceFraction, *origin)
 	defer shutdownOTel(ctx)
@@ -121,7 +122,8 @@ func main() {
 
 	fetchedRootsBackupStorage, err := posix.NewRootsStorage(ctx, *storageDir)
 	if err != nil {
-		klog.Exitf("failed to initialize POSIX backup storage for remotely fetched roots: %v", err)
+		slog.ErrorContext(ctx, "failed to initialize POSIX backup storage for remotely fetched roots", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	if len(rootsRemoteFetchURLs) == 0 {
@@ -143,7 +145,7 @@ func main() {
 		RejectRoots:              rootsRejectFingerprints,
 	}
 	if *acceptSHA1 {
-		klog.Info(`**** WARNING **** This server will accept chains signed
+		slog.InfoContext(ctx, `**** WARNING **** This server will accept chains signed
 using SHA-1 based algorithms. This feature is available to allow chains
 submitted by Chrome's Merge Delay Monitor Root for the time being, but will
 eventually go away. See /internal/lax509/README.md for more information.`)
@@ -156,11 +158,11 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newStorage, *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
-		klog.Exitf("Can't initialize CT HTTP Server: %v", err)
+		slog.ErrorContext(ctx, "Can't initialize CT HTTP Server", slog.Any("error", err))
+		os.Exit(1)
 	}
 
-	klog.CopyStandardLogTo("WARNING")
-	klog.Info("**** CT HTTP Server Starting ****")
+	slog.InfoContext(ctx, "**** CT HTTP Server Starting ****")
 	http.Handle("/", logHandler)
 
 	// Bring up the HTTP server and serve until we get a signal not to.
@@ -178,20 +180,19 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 		// TODO(phboneff): maybe wait for the sequencer queue to be empty?
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 		defer cancel()
-		klog.Info("Shutting down HTTP server...")
+		slog.InfoContext(ctx, "Shutting down HTTP server...")
 		if err := srv.Shutdown(ctx); err != nil {
-			klog.Errorf("srv.Shutdown(): %v", err)
+			slog.ErrorContext(ctx, "srv.Shutdown()", slog.Any("error", err))
 		}
-		klog.Info("HTTP server shutdown")
+		slog.InfoContext(ctx, "HTTP server shutdown")
 	})
 
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-		klog.Warningf("Server exited: %v", err)
+		slog.WarnContext(ctx, "Server exited", slog.Any("error", err))
 	}
 	// Wait will only block if the function passed to awaitSignal was called,
 	// in which case it'll block until the HTTP server has gracefully shutdown
 	shutdownWG.Wait()
-	klog.Flush()
 }
 
 // awaitSignal waits for standard termination signals, then runs the given
@@ -203,8 +204,7 @@ func awaitSignal(doneFn func()) {
 
 	// Now block main and wait for a signal
 	sig := <-sigs
-	klog.Warningf("Signal received: %v", sig)
-	klog.Flush()
+	slog.WarnContext(context.Background(), "Signal received", slog.Any("signal", sig))
 
 	doneFn()
 }
@@ -360,19 +360,23 @@ func signerFromFlags() crypto.Signer {
 		kf = os.Getenv("LOG_PRIVATE_KEY")
 	}
 	if kf == "" {
-		klog.Exitf("Must specify --priv_key or LOG_PRIVATE_KEY environment variable.")
+		slog.ErrorContext(context.Background(), "Must specify --priv_key or LOG_PRIVATE_KEY environment variable.")
+		os.Exit(1)
 	}
 	r, err := os.ReadFile(kf)
 	if err != nil {
-		klog.Exitf("Failed to read private key from %q: %v", kf, err)
+		slog.ErrorContext(context.Background(), "Failed to read private key", slog.String("path", kf), slog.Any("error", err))
+		os.Exit(1)
 	}
 	block, _ := pem.Decode(r)
 	if err != nil {
-		klog.Exitf("Failed to parse PEM private key: %v", err)
+		slog.ErrorContext(context.Background(), "Failed to parse PEM private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	k, err := x509.ParseECPrivateKey(block.Bytes)
 	if err != nil {
-		klog.Exitf("Failed to parse private key: %v", err)
+		slog.ErrorContext(context.Background(), "Failed to parse private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	return k
 }
@@ -396,15 +400,18 @@ func notBeforeRLFromFlags() *tesseract.NotBeforeRL {
 	}
 	bits := strings.Split(*notBeforeRL, ":")
 	if len(bits) != 2 {
-		klog.Exitf("Invalid format for --rate_limit_old_not_before flag")
+		slog.ErrorContext(context.Background(), "Invalid format for --rate_limit_old_not_before flag")
+		os.Exit(1)
 	}
 	a, err := time.ParseDuration(bits[0])
 	if err != nil {
-		klog.Exitf("Invalid age passed to --rate_limit_old_not_before flag %q: %v", bits[0], err)
+		slog.ErrorContext(context.Background(), "Invalid age passed to --rate_limit_old_not_before flag", slog.String("age", bits[0]), slog.Any("error", err))
+		os.Exit(1)
 	}
 	l, err := strconv.ParseFloat(bits[1], 64)
 	if err != nil {
-		klog.Exitf("Invalid rate limit passed to --rate_limit_old_not_before %q: %v", bits[1], err)
+		slog.ErrorContext(context.Background(), "Invalid rate limit passed to --rate_limit_old_not_before", slog.String("limit", bits[1]), slog.Any("error", err))
+		os.Exit(1)
 	}
 	return &tesseract.NotBeforeRL{AgeThreshold: a, RateLimit: l}
 }

--- a/cmd/tesseract/posix/otel.go
+++ b/cmd/tesseract/posix/otel.go
@@ -17,6 +17,8 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"os"
 
 	t_otel "github.com/transparency-dev/tesseract/internal/otel"
 	"go.opentelemetry.io/otel"
@@ -27,8 +29,6 @@ import (
 
 	"go.opentelemetry.io/contrib/exporters/autoexport"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
-
-	"k8s.io/klog/v2"
 )
 
 // initOTel initialises the open telemetry support for metrics.
@@ -45,13 +45,14 @@ func initOTel(ctx context.Context, traceFraction float64, origin string) func(co
 		}
 		shutdownFuncs = nil
 		if err != nil {
-			klog.Errorf("OTel shutdown: %v", err)
+			slog.ErrorContext(ctx, "OTel shutdown", slog.Any("error", err))
 		}
 	}
 
 	mr, err := autoexport.NewMetricReader(ctx)
 	if err != nil {
-		klog.Exitf("Failed to create the OTLP metric reader: %v", err)
+		slog.ErrorContext(ctx, "Failed to create the OTLP metric reader", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	resources, err := resource.New(ctx,
@@ -63,7 +64,8 @@ func initOTel(ctx context.Context, traceFraction float64, origin string) func(co
 		resource.WithFromEnv(), // unpacks OTEL_RESOURCE_ATTRIBUTES
 	)
 	if err != nil {
-		klog.Exitf("Failed to detect resources: %v", err)
+		slog.ErrorContext(ctx, "Failed to detect resources", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	mp := sdkmetric.NewMeterProvider(
@@ -75,7 +77,8 @@ func initOTel(ctx context.Context, traceFraction float64, origin string) func(co
 
 	te, err := autoexport.NewSpanExporter(ctx)
 	if err != nil {
-		klog.Exitf("Failed to create the OTLP span exporter: %v", err)
+		slog.ErrorContext(ctx, "Failed to create the OTLP span exporter", slog.Any("error", err))
+		os.Exit(1)
 	}
 	// initialize a TracerProvier that periodically exports to the GCP exporter.
 	tp := sdktrace.NewTracerProvider(
@@ -87,7 +90,8 @@ func initOTel(ctx context.Context, traceFraction float64, origin string) func(co
 	otel.SetTracerProvider(tp)
 
 	if err := runtime.Start(runtime.WithMeterProvider(mp)); err != nil {
-		klog.Exitf("Failed to start exporting Go runtime metrics: %v", err)
+		slog.ErrorContext(ctx, "Failed to start exporting Go runtime metrics", slog.Any("error", err))
+		os.Exit(1)
 	}
 	return shutdown
 }

--- a/ctlog.go
+++ b/ctlog.go
@@ -24,6 +24,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -32,7 +33,6 @@ import (
 	"github.com/transparency-dev/tesseract/internal/ct"
 	"github.com/transparency-dev/tesseract/internal/x509util"
 	"github.com/transparency-dev/tesseract/storage"
-	"k8s.io/klog/v2"
 )
 
 // ChainValidationConfig contains parameters to configure chain validation.
@@ -148,39 +148,39 @@ func newChainValidator(ctx context.Context, cfg ChainValidationConfig) (ct.Chain
 			certs = append(certs, kv.V)
 		}
 		parsed, added := roots.AppendCertsFromPEMs(certs...)
-		klog.Infof("Fetched %d roots, parsed %d, and loaded %d new ones from remote root backup storage", len(certs), parsed, added)
+		slog.InfoContext(ctx, "Fetched roots from remote root backup storage", slog.Int("fetched", len(certs)), slog.Int("parsed", parsed), slog.Int("added", added))
 	}
 
 	if cfg.RootsRemoteFetchInterval > 0 && len(cfg.RootsRemoteFetchURLs) > 0 {
 		fetchAndAppendRemoteRoots := func(url string) {
 			rr, err := ccadb.Fetch(ctx, url, []string{ccadb.ColPEM})
 			if err != nil {
-				klog.Errorf("Couldn't fetch roots from %q: %s", url, err)
+				slog.ErrorContext(ctx, "Couldn't fetch roots", slog.String("url", url), slog.Any("error", err))
 				return
 			}
 			pems := make([][]byte, 0, len(rr))
 			for _, r := range rr {
 				if len(r) < 1 {
-					klog.Errorf("Couldn't parse root from %q: empty row", url)
+					slog.ErrorContext(ctx, "Couldn't parse root: empty row", slog.String("url", url))
 					continue
 				}
 				pems = append(pems, r[0])
 				if cfg.RootsRemoteFetchBackup != nil {
 					block, _ := pem.Decode(r[0])
 					if block == nil {
-						klog.Errorf("Failed to decode PEM block in data fetched from %q", url)
+						slog.ErrorContext(ctx, "Failed to decode PEM block in fetched data", slog.String("url", url))
 						continue
 					}
 					sha := sha256.Sum256(block.Bytes)
 					key := []byte(hex.EncodeToString(sha[:]))
 					if err := cfg.RootsRemoteFetchBackup.AddIfNotExist(ctx, []storage.KV{{K: key, V: r[0]}}); err != nil {
-						klog.Errorf("Couldn't store roots %q: %v", string(key), err)
+						slog.ErrorContext(ctx, "Couldn't store roots", slog.String("key", string(key)), slog.Any("error", err))
 						continue
 					}
 				}
 			}
 			parsed, added := roots.AppendCertsFromPEMs(pems...)
-			klog.Infof("Fetched %d roots, parsed %d, and loaded %d new ones from %q", len(pems), parsed, added, url)
+			slog.InfoContext(ctx, "Fetched roots", slog.Int("fetched", len(pems)), slog.Int("parsed", parsed), slog.Int("added", added), slog.String("url", url))
 		}
 
 		for _, url := range cfg.RootsRemoteFetchURLs {

--- a/deployment/live/aws/test/README.md
+++ b/deployment/live/aws/test/README.md
@@ -143,7 +143,7 @@ go run ./cmd/tesseract/aws \
   --antispam_db_name=antispam_db \
   --signer_public_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
   --signer_private_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID} \
-  --v=1
+  --slog_level=-4
 ```
 
 Confirm that TesseraCT is running properly by fetching a checkpoint from
@@ -243,7 +243,7 @@ go run ./cmd/tesseract/aws \
   --antispam_db_name=antispam_db \
   --signer_public_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
   --signer_private_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID} \
-  --v=1
+  --slog_level=-4
 ```
 
 Confirm that TesseraCT is running properly by fetching a checkpoint from
@@ -263,7 +263,7 @@ go run github.com/google/certificate-transparency-go/preload/preloader@master \
   --num_workers=8 \
   --parallel_fetch=4 \
   --parallel_submit=4 \
-  --v=1
+  --slog_level=-4
 ```
 
 Since the source and destination log

--- a/deployment/live/gcp/test/README.md
+++ b/deployment/live/gcp/test/README.md
@@ -132,7 +132,7 @@ go run ./cmd/tesseract/gcp/ \
   --signer_public_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
   --signer_private_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID} \
   --otel_project_id=${GOOGLE_PROJECT} \
-  --v=1
+  --slog_level=-4
 ```
 
 Confirm that TesseraCT is running properly by fetching a checkpoint from
@@ -229,7 +229,7 @@ go run ./cmd/tesseract/gcp/ \
   --signer_public_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
   --signer_private_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID} \
   --otel_project_id=${GOOGLE_PROJECT} \
-  --v=1
+  --slog_level=-4
 ```
 
 Confirm that TesseraCT is running properly by fetching a checkpoint from
@@ -249,7 +249,7 @@ go run github.com/google/certificate-transparency-go/preload/preloader@master \
   --num_workers=8 \
   --parallel_fetch=4 \
   --parallel_submit=4 \
-  --v=1
+  --slog_level=-4
 ```
 
 Since the source and destination log

--- a/deployment/modules/aws/tesseract/conformance/main.tf
+++ b/deployment/modules/aws/tesseract/conformance/main.tf
@@ -178,7 +178,7 @@ resource "aws_ecs_task_definition" "conformance" {
       "--enable_publication_awaiter=true",
       formatlist("--roots_remote_fetch_url=%s", var.roots_remote_fetch_url),
       "--roots_remote_fetch_interval=${var.roots_remote_fetch_interval}",
-      "-v=2",
+      "--slog_level=-4",
     ]),
     "logConfiguration" : {
       "logDriver" : "awslogs",
@@ -258,12 +258,11 @@ resource "aws_ecs_task_definition" "hammer" {
       "--log_url=https://${module.storage.s3_bucket_regional_domain_name}",
       "--write_log_url=http://${aws_service_discovery_service.conformance.name}.${aws_service_discovery_private_dns_namespace.internal.name}:${local.port}/ci-static-ct",
       "--show_ui=false",
-      "--logtostderr",
       "--num_writers=256",
       "--max_write_ops=256",
       "--num_mmd_verifiers=1024",
       "--leaf_write_goal=10000",
-      "-v=3",
+      "--slog_level=-4",
     ],
     "logConfiguration" : {
       "logDriver" : "awslogs",

--- a/deployment/modules/gcp/cloudbuild/conformance/main.tf
+++ b/deployment/modules/gcp/cloudbuild/conformance/main.tf
@@ -224,11 +224,10 @@ resource "google_cloudbuild_trigger" "build_trigger" {
           --log_public_key="$(cat /workspace/conformance_log_public_key)" \
           --log_url="https://storage.googleapis.com/$(cat /workspace/conformance_bucket_name)/" \
           --write_log_url="$(cat /workspace/conformance_url)/${local.origin}" \
-          -v=1 \
+          --slog_level=-4 \
           --show_ui=false \
           --bearer_token="$(cat /workspace/cb_access)" \
           --bearer_token_write="$(cat /workspace/cb_identity)" \
-          --logtostderr \
           --num_writers=256 \
           --max_write_ops=256 \
           --num_mmd_verifiers=256 \

--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -40,8 +40,6 @@ resource "google_cloud_run_v2_service" "default" {
       image = var.server_docker_image
       name  = "tesseract"
       args = flatten([
-        "--logtostderr",
-        "--v=1",
         "--otel_project_id=${var.project_id}",
         "--slog_level=-4",
         "--http_endpoint=:6962",

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -39,8 +39,6 @@ locals {
 
   # tesseract_args are provided to the tesseract command.
   tesseract_args = concat([
-    "-logtostderr",
-    "-v=0",
     "-slog_level=-4",
     "-slog_to_cloud_api=true",
     "-otel_project_id=${var.project_id}",

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	golang.org/x/time v0.15.0
 	google.golang.org/api v0.274.0
 	google.golang.org/grpc v1.80.0
-	k8s.io/klog/v2 v2.140.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -482,5 +482,3 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
-k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=

--- a/internal/ccadb/ccadb.go
+++ b/internal/ccadb/ccadb.go
@@ -19,11 +19,10 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
-
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -58,7 +57,7 @@ func Fetch(ctx context.Context, url string, fetchHeaders []string) ([][][]byte, 
 
 	defer func() {
 		if err := rsp.Body.Close(); err != nil {
-			klog.Errorf("resp.Body.Close(): %v", err)
+			slog.ErrorContext(ctx, "resp.Body.Close()", slog.Any("error", err))
 		}
 	}()
 

--- a/internal/client/fetcher.go
+++ b/internal/client/fetcher.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/cenkalti/backoff/v5"
 	"github.com/transparency-dev/tessera/api/layout"
-	"k8s.io/klog/v2"
 )
 
 // NewHTTPFetcher creates a new HTTPFetcher for the log rooted at the given URL, using
@@ -122,7 +122,7 @@ func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 
 		defer func() {
 			if err := r.Body.Close(); err != nil {
-				klog.Errorf("resp.Body.Close(): %v", err)
+				slog.ErrorContext(ctx, "resp.Body.Close()", slog.Any("error", err))
 			}
 		}()
 		return io.ReadAll(r.Body)

--- a/internal/client/gcp/fetcher.go
+++ b/internal/client/gcp/fetcher.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 
 	gcs "cloud.google.com/go/storage"
 	"github.com/transparency-dev/tessera/api/layout"
 	"github.com/transparency-dev/tesseract/internal/client"
-	"k8s.io/klog/v2"
 )
 
 // NewGSFetcher creates a new GSFetcher for the Google Cloud Storage bucket, using
@@ -57,7 +57,7 @@ func (f GSFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 	}
 	defer func() {
 		if err := r.Close(); err != nil {
-			klog.Errorf("r.Close(): %v", err)
+			slog.ErrorContext(ctx, "r.Close()", slog.Any("error", err))
 		}
 	}()
 

--- a/internal/ct/chain_validation.go
+++ b/internal/ct/chain_validation.go
@@ -16,11 +16,13 @@ package ct
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -28,7 +30,6 @@ import (
 	"github.com/transparency-dev/tesseract/internal/lax509"
 	"github.com/transparency-dev/tesseract/internal/types/rfc6962"
 	"github.com/transparency-dev/tesseract/internal/x509util"
-	"k8s.io/klog/v2"
 )
 
 var stringToKeyUsage = map[string]x509.ExtKeyUsage{
@@ -56,7 +57,7 @@ func ParseExtKeyUsages(kus []string) ([]x509.ExtKeyUsage, error) {
 			// If "Any" is specified, then we can ignore the entire list and
 			// just disable EKU checking.
 			if ku == x509.ExtKeyUsageAny {
-				klog.Info("Found ExtKeyUsageAny, allowing all EKUs")
+				slog.InfoContext(context.Background(), "Found ExtKeyUsageAny, allowing all EKUs")
 				lExtKeyUsages = nil
 				break
 			}
@@ -306,9 +307,9 @@ func (cv chainValidator) Validate(unverifiedChain []*x509.Certificate, expecting
 	// The type of the leaf must match the one the handler expects
 	if isPrecert != expectingPrecert {
 		if expectingPrecert {
-			klog.Warningf("Cert (or precert with invalid CT ext) submitted as precert chain: %v", unverifiedChain)
+			slog.WarnContext(context.Background(), "Cert (or precert with invalid CT ext) submitted as precert chain", slog.Any("chain", unverifiedChain))
 		} else {
-			klog.Warningf("Precert (or cert with invalid CT ext) submitted as cert chain: %v", unverifiedChain)
+			slog.WarnContext(context.Background(), "Precert (or cert with invalid CT ext) submitted as cert chain", slog.Any("chain", unverifiedChain))
 		}
 		return nil, fmt.Errorf("cert / precert mismatch: %T", expectingPrecert)
 	}

--- a/internal/ct/ctlog.go
+++ b/internal/ct/ctlog.go
@@ -7,14 +7,15 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/ctonly"
 	"github.com/transparency-dev/tesseract/internal/types/rfc6962"
 	"github.com/transparency-dev/tesseract/storage"
-	"k8s.io/klog/v2"
 )
 
 // log provides objects and functions to implement static-ct-api write api.
@@ -100,12 +101,14 @@ func NewLog(ctx context.Context, origin string, signer crypto.Signer, cv ChainVa
 
 	cpSigner, err := NewCpSigner(signer, origin, ts)
 	if err != nil {
-		klog.Exitf("failed to create checkpoint Signer: %v", err)
+		slog.ErrorContext(ctx, "failed to create checkpoint Signer", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	storage, err := cs(ctx, cpSigner)
 	if err != nil {
-		klog.Exitf("failed to initiate storage backend: %v", err)
+		slog.ErrorContext(ctx, "failed to initiate storage backend", slog.Any("error", err))
+		os.Exit(1)
 	}
 	log.storage = storage
 

--- a/internal/ct/handlers.go
+++ b/internal/ct/handlers.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"math/rand/v2"
 	"net/http"
@@ -41,7 +42,6 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/net/idna"
 	"golang.org/x/time/rate"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -206,13 +206,13 @@ func (a appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Verify that the request was received at an URL starting with the origin, as per https://c2sp.org/static-ct-api.
 	// Don't block requests that don't satisfy this to allow for custom proxy configuration, or custom request routing.
 	if err := receivedAtOrigin(r, a.log.origin); err != nil {
-		klog.Warningf("%s: %s the request was received on a URL which is not prefixed with the configured origin: %v", a.log.origin, a.name, err)
+		slog.WarnContext(logCtx, "the request was received on a URL which is not prefixed with the configured origin", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.Any("error", err))
 	}
 
-	klog.V(2).Infof("%s: request %v %q => %s", a.log.origin, r.Method, r.URL, a.name)
+	slog.DebugContext(logCtx, "request received", slog.String("origin", a.log.origin), slog.String("method", r.Method), slog.String("url", r.URL.String()), slog.String("name", a.name))
 	// TODO(phboneff): add a.Method directly on the handler path and remove this test.
 	if r.Method != a.method {
-		klog.Warningf("%s: %s wrong HTTP method: %v", a.log.origin, a.name, r.Method)
+		slog.WarnContext(logCtx, "wrong HTTP method", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.String("method", r.Method))
 		a.opts.sendHTTPError(w, http.StatusMethodNotAllowed, fmt.Errorf("method not allowed: %s", r.Method))
 		a.opts.RequestLog.status(logCtx, http.StatusMethodNotAllowed)
 		return
@@ -237,14 +237,14 @@ func (a appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	attrs = append(attrs, hattrs...)
 	attrs = append(attrs, codeKey.Int(statusCode))
 	a.opts.RequestLog.status(ctx, statusCode)
-	klog.V(2).Infof("%s: %s <= st=%d", a.log.origin, a.name, statusCode)
+	slog.DebugContext(ctx, "handler response", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.Int("status", statusCode))
 	rspCounter.Add(logCtx, 1, metric.WithAttributes(attrs...))
 	if err != nil {
 		if errors.Is(err, context.Canceled) && errors.Is(r.Context().Err(), context.Canceled) {
 			statusCode = ClientClosedRequestStatus
 			err = fmt.Errorf("client closed the connection: %v", err)
 		}
-		klog.Warningf("%s: %s handler error: %v", a.log.origin, a.name, err)
+		slog.WarnContext(ctx, "handler error", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.Any("error", err))
 		a.opts.sendHTTPError(w, statusCode, err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -253,7 +253,7 @@ func (a appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Additional check, for consistency the handler must return an error for non-200 st
 	if statusCode != http.StatusOK {
-		klog.Warningf("%s: %s handler non 200 without error: %d %v", a.log.origin, a.name, statusCode, err)
+		slog.WarnContext(ctx, "handler non 200 without error", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.Int("status", statusCode), slog.Any("error", err))
 		a.opts.sendHTTPError(w, http.StatusInternalServerError, fmt.Errorf("http handler misbehaved, st: %d", statusCode))
 		if statusCode >= 500 {
 			span.SetStatus(codes.Error, "handler non-200 without error")
@@ -275,7 +275,7 @@ type RateLimits struct {
 func (r *RateLimits) NotBefore(age time.Duration, limit float64) {
 	r.notBeforeLimit = age
 	r.notBefore = rate.NewLimiter(rate.Limit(limit), int(math.Ceil(limit)))
-	klog.Infof("Configured NotBefore limiter with %0.2f qps for certs aged >= %s", limit, age)
+	slog.InfoContext(context.Background(), "Configured NotBefore limiter", slog.Float64("qps", limit), slog.Duration("min_age", age))
 }
 
 // Dedup configures a rate limit on entries being deduplicated.
@@ -283,7 +283,7 @@ func (r *RateLimits) NotBefore(age time.Duration, limit float64) {
 // Submissions will be subject to the specified number of entries per second.
 func (r *RateLimits) Dedup(limit float64) {
 	r.dedup = rate.NewLimiter(rate.Limit(limit), int(math.Ceil(limit)))
-	klog.Infof("Configured DedupInFlight limiter with %0.2f qps", limit)
+	slog.InfoContext(context.Background(), "Configured DedupInFlight limiter", slog.Float64("qps", limit))
 }
 
 // AcceptNotBefore returns true if the provided chain should be accepted, and false otherwise.
@@ -391,24 +391,25 @@ func parseBodyAsJSONChain(r *http.Request) (rfc6962.AddChainRequest, error) {
 	buf := getBuffer()
 	defer returnBuffer(buf)
 
+	ctx := r.Context()
 	if _, err := buf.ReadFrom(r.Body); err != nil {
 		if mbe, ok := err.(*http.MaxBytesError); ok {
-			klog.V(1).Infof("Request body exceeds %d-byte limit", mbe.Limit)
+			slog.DebugContext(ctx, "Request body exceeds limit", slog.Int64("limit", mbe.Limit))
 			return rfc6962.AddChainRequest{}, fmt.Errorf("certificate chain exceeds %d-byte limit: %w", mbe.Limit, err)
 		}
-		klog.V(1).Infof("Failed to read request body: %v", err)
+		slog.DebugContext(ctx, "Failed to read request body", slog.Any("error", err))
 		return rfc6962.AddChainRequest{}, err
 	}
 
 	var req rfc6962.AddChainRequest
 	if err := json.Unmarshal(buf.Bytes(), &req); err != nil {
-		klog.V(1).Infof("Failed to parse request body: %v", err)
+		slog.DebugContext(ctx, "Failed to parse request body", slog.Any("error", err))
 		return rfc6962.AddChainRequest{}, err
 	}
 
 	// The cert chain is not allowed to be empty. We'll defer other validation for later
 	if len(req.Chain) == 0 {
-		klog.V(1).Infof("Request chain is empty: %q", buf.Bytes())
+		slog.DebugContext(ctx, "Request chain is empty", slog.String("body", buf.String()))
 		return rfc6962.AddChainRequest{}, errors.New("cert chain was empty")
 	}
 
@@ -478,7 +479,7 @@ func addChainInternal(ctx context.Context, opts *HandlerOptions, log *log, w htt
 		return http.StatusInternalServerError, nil, fmt.Errorf("failed to store issuer chain: %s", err)
 	}
 
-	klog.V(2).Infof("%s: %s => storage.Add", log.origin, method)
+	slog.DebugContext(ctx, "storage.Add", slog.String("origin", log.origin), slog.String("method", method))
 	future, err := log.storage.Add(ctx, entry)
 	// helper function to return a 429
 	tooManyRequests := func(reason string) (int, []attribute.KeyValue, error) {
@@ -541,7 +542,7 @@ func addChainInternal(ctx context.Context, opts *HandlerOptions, log *log, w htt
 		// reason is logged and http status is already set
 		return http.StatusInternalServerError, nil, fmt.Errorf("failed to write response: %s", err)
 	}
-	klog.V(3).Infof("%s: %s <= SCT", log.origin, method)
+	slog.DebugContext(ctx, "SCT issued", slog.String("origin", log.origin), slog.String("method", method))
 	if !index.IsDup {
 		lastSCTTimestamp.Record(ctx, otel.Clamp64(sct.Timestamp), metric.WithAttributes(originKey.String(log.origin)))
 		lastSCTIndex.Record(ctx, otel.Clamp64(index.Index), metric.WithAttributes(originKey.String(log.origin)))
@@ -580,7 +581,7 @@ func getRoots(ctx context.Context, opts *HandlerOptions, log *log, w http.Respon
 	enc := json.NewEncoder(w)
 	err := enc.Encode(jsonMap)
 	if err != nil {
-		klog.Warningf("%s: get_roots failed: %v", log.origin, err)
+		slog.WarnContext(ctx, "get_roots failed", slog.String("origin", log.origin), slog.Any("error", err))
 		return http.StatusInternalServerError, nil, fmt.Errorf("get-roots failed with: %s", err)
 	}
 

--- a/internal/ct/handlers_test.go
+++ b/internal/ct/handlers_test.go
@@ -48,7 +48,6 @@ import (
 	"github.com/transparency-dev/tesseract/storage"
 	"github.com/transparency-dev/tesseract/storage/posix"
 	"golang.org/x/mod/sumdb/note"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -164,7 +163,7 @@ func newPOSIXStorageFunc(t *testing.T, root string) storage.CreateStorage {
 	return func(ctx context.Context, signer note.Signer) (*storage.CTStorage, error) {
 		driver, err := tposix.New(ctx, tposix.Config{Path: path.Join(root, logDir)})
 		if err != nil {
-			klog.Fatalf("Failed to initialize POSIX Tessera storage driver: %v", err)
+			t.Fatalf("Failed to initialize POSIX Tessera storage driver: %v", err)
 		}
 
 		asOpts := badger_as.AntispamOpts{
@@ -173,7 +172,7 @@ func newPOSIXStorageFunc(t *testing.T, root string) storage.CreateStorage {
 		}
 		antispam, err := badger_as.NewAntispam(ctx, path.Join(root, "dedup.db"), asOpts)
 		if err != nil {
-			klog.Exitf("Failed to create new GCP antispam storage: %v", err)
+			t.Fatalf("Failed to create new GCP antispam storage: %v", err)
 		}
 
 		opts := tessera.NewAppendOptions().
@@ -184,12 +183,12 @@ func newPOSIXStorageFunc(t *testing.T, root string) storage.CreateStorage {
 
 		appender, _, reader, err := tessera.NewAppender(ctx, driver, opts)
 		if err != nil {
-			klog.Fatalf("Failed to initialize POSIX Tessera appender: %v", err)
+			t.Fatalf("Failed to initialize POSIX Tessera appender: %v", err)
 		}
 
 		issuerStorage, err := posix.NewIssuerStorage(ctx, path.Join(root, logDir))
 		if err != nil {
-			klog.Fatalf("failed to initialize InMemory issuer storage: %v", err)
+			t.Fatalf("failed to initialize InMemory issuer storage: %v", err)
 		}
 
 		sopts := storage.CTStorageOptions{
@@ -200,7 +199,7 @@ func newPOSIXStorageFunc(t *testing.T, root string) storage.CreateStorage {
 		}
 		s, err := storage.NewCTStorage(t.Context(), &sopts)
 		if err != nil {
-			klog.Fatalf("Failed to initialize CTStorage: %v", err)
+			t.Fatalf("Failed to initialize CTStorage: %v", err)
 		}
 		return s, nil
 	}

--- a/internal/ct/otel.go
+++ b/internal/ct/otel.go
@@ -15,9 +15,12 @@
 package ct
 
 import (
+	"context"
+	"log/slog"
+	"os"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"k8s.io/klog/v2"
 )
 
 const name = "github.com/transparency-dev/tesseract/internal/ct"
@@ -38,7 +41,8 @@ var (
 
 func mustCreate[T any](t T, err error) T {
 	if err != nil {
-		klog.Exit(err.Error())
+		slog.ErrorContext(context.Background(), err.Error())
+		os.Exit(1)
 	}
 	return t
 }

--- a/internal/ct/requestlog.go
+++ b/internal/ct/requestlog.go
@@ -18,12 +18,9 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/hex"
+	"log/slog"
 	"time"
-
-	"k8s.io/klog/v2"
 )
-
-const vLevel = 9
 
 // requestLog allows implementations to do structured logging of TesseraCT
 // request parameters, submitted chains and other internal details that
@@ -66,37 +63,37 @@ type DefaultRequestLog struct {
 
 // start logs the start of request processing.
 func (dlr *DefaultRequestLog) start(ctx context.Context) context.Context {
-	klog.V(vLevel).Info("RL: Start")
+	slog.DebugContext(ctx, "RL: Start")
 	return ctx
 }
 
 // origin logs the origin of the CT log that this request is for.
-func (dlr *DefaultRequestLog) origin(_ context.Context, p string) {
-	klog.V(vLevel).Infof("RL: LogOrigin: %s", p)
+func (dlr *DefaultRequestLog) origin(ctx context.Context, p string) {
+	slog.DebugContext(ctx, "RL: LogOrigin", slog.String("origin", p))
 }
 
 // addDERToChain logs the raw bytes of a submitted certificate.
-func (dlr *DefaultRequestLog) addDERToChain(_ context.Context, d []byte) {
+func (dlr *DefaultRequestLog) addDERToChain(ctx context.Context, d []byte) {
 	// Explicit hex encoding below to satisfy CodeQL:
-	klog.V(vLevel).Infof("RL: Cert DER: %s", hex.EncodeToString(d))
+	slog.DebugContext(ctx, "RL: Cert DER", slog.String("der", hex.EncodeToString(d)))
 }
 
 // addCertToChain logs some issuer / subject / timing fields from a
 // certificate that is part of a submitted chain.
-func (dlr *DefaultRequestLog) addCertToChain(_ context.Context, cert *x509.Certificate) {
-	klog.V(vLevel).Infof("RL: Cert: Sub: %s Iss: %s notBef: %s notAft: %s",
-		cert.Subject,
-		cert.Issuer,
-		cert.NotBefore.Format(time.RFC1123Z),
-		cert.NotAfter.Format(time.RFC1123Z))
+func (dlr *DefaultRequestLog) addCertToChain(ctx context.Context, cert *x509.Certificate) {
+	slog.DebugContext(ctx, "RL: Cert",
+		slog.String("subject", cert.Subject.String()),
+		slog.String("issuer", cert.Issuer.String()),
+		slog.String("not_before", cert.NotBefore.Format(time.RFC1123Z)),
+		slog.String("not_after", cert.NotAfter.Format(time.RFC1123Z)))
 }
 
 // issueSCT logs an SCT that will be issued to a client.
-func (dlr *DefaultRequestLog) issueSCT(_ context.Context, sct []byte) {
-	klog.V(vLevel).Infof("RL: Issuing SCT: %x", sct)
+func (dlr *DefaultRequestLog) issueSCT(ctx context.Context, sct []byte) {
+	slog.DebugContext(ctx, "RL: Issuing SCT", slog.String("sct", hex.EncodeToString(sct)))
 }
 
 // status logs the response HTTP status code after processing completes.
-func (dlr *DefaultRequestLog) status(_ context.Context, s int) {
-	klog.V(vLevel).Infof("RL: Status: %d", s)
+func (dlr *DefaultRequestLog) status(ctx context.Context, s int) {
+	slog.DebugContext(ctx, "RL: Status", slog.Int("status", s))
 }

--- a/internal/hammer/chain.go
+++ b/internal/hammer/chain.go
@@ -15,14 +15,15 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"log/slog"
 	"math/big"
 	"time"
 
 	"github.com/transparency-dev/tesseract/internal/types/rfc6962"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -75,7 +76,7 @@ func (g *chainGenerator) certificate(serialNumber int64) []byte {
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, g.intermediateCert, g.leafCertPublicKey, g.intermediateKey)
 	if err != nil {
-		klog.Error(err)
+		slog.ErrorContext(context.Background(), "CreateCertificate", slog.Any("error", err))
 		return nil
 	}
 

--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -31,6 +31,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/rand/v2"
 	"net"
 	"net/http"
@@ -50,8 +51,6 @@ import (
 	"github.com/transparency-dev/tesseract/internal/types/staticct"
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/net/http2"
-
-	"k8s.io/klog/v2"
 )
 
 func init() {
@@ -91,13 +90,14 @@ var (
 
 	httpTimeout = flag.Duration("http_timeout", 30*time.Second, "Timeout for HTTP requests")
 	forceHTTP2  = flag.Bool("force_http2", false, "Use HTTP/2 connections *only*")
+	slogLevel   = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
 
 	hc *http.Client
 )
 
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
 
 	hc = &http.Client{
 		Transport: &http.Transport{
@@ -128,7 +128,8 @@ func main() {
 
 	logSigV, err := logSigVerifier(*origin, *logPubKey)
 	if err != nil {
-		klog.Exitf("Failed to create verifier: %v", err)
+		slog.ErrorContext(ctx, "Failed to create verifier", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	r := mustCreateReaders(ctx, logURL)
@@ -141,12 +142,14 @@ func main() {
 	cons := client.UnilateralConsensus(r.ReadCheckpoint)
 	tracker, err := client.NewLogStateTracker(ctx, r.ReadCheckpoint, r.ReadTile, cpRaw, logSigV, logSigV.Name(), cons)
 	if err != nil {
-		klog.Exitf("Failed to create LogStateTracker: %v", err)
+		slog.ErrorContext(ctx, "Failed to create LogStateTracker", slog.Any("error", err))
+		os.Exit(1)
 	}
 	// Fetch initial state of log
 	_, _, _, err = tracker.Update(ctx)
 	if err != nil {
-		klog.Exitf("Failed to get initial state of the log: %v", err)
+		slog.ErrorContext(ctx, "Failed to get initial state of the log", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	ha := loadtest.NewHammerAnalyser(func() uint64 { return tracker.LatestConsistent.Size })
@@ -154,21 +157,26 @@ func main() {
 
 	intermediateCACert, err := loadIntermediateCACert(*intermediateCACertPath)
 	if err != nil {
-		klog.Exitf("Failed to load intermediate CA certificate from %s: %v", *intermediateCACertPath, err)
+		slog.ErrorContext(ctx, "Failed to load intermediate CA certificate", slog.String("path", *intermediateCACertPath), slog.Any("error", err))
+		os.Exit(1)
 	}
 	intermediateCAKey, err := loadPrivateKey(*intermediateCAKeyPath)
 	if err != nil {
-		klog.Exitf("Failed to load intermediate CA private key from %s: %v", *intermediateCAKeyPath, err)
+		slog.ErrorContext(ctx, "Failed to load intermediate CA private key", slog.String("path", *intermediateCAKeyPath), slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := verifySupportedKeyAlgorithm(intermediateCAKey); err != nil {
-		klog.Exitf("Failed to support intermediate CA key algorithm for generating deterministic certificate: %v", err)
+		slog.ErrorContext(ctx, "Failed to support intermediate CA key algorithm for generating deterministic certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	privateKey, err := loadPrivateKey(*certSigningPrivateKeyPath)
 	if err != nil {
-		klog.Exitf("Failed to load certificate signing private key from %s: %v", *certSigningPrivateKeyPath, err)
+		slog.ErrorContext(ctx, "Failed to load certificate signing private key", slog.String("path", *certSigningPrivateKeyPath), slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := verifySupportedKeyAlgorithm(privateKey); err != nil {
-		klog.Exitf("Failed to support certificate signing private key algorithm for generating deterministic certificate: %v", err)
+		slog.ErrorContext(ctx, "Failed to support certificate signing private key algorithm for generating deterministic certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	gen := newLeafGenerator(tracker.LatestConsistent.Size, *dupChance, intermediateCACert, intermediateCAKey, privateKey)
@@ -188,7 +196,7 @@ func main() {
 		go func() {
 			startTime := time.Now()
 			goal := tracker.LatestConsistent.Size + uint64(*leafWriteGoal)
-			klog.Infof("Will exit once tree size is at least %d", goal)
+			slog.InfoContext(ctx, "Will exit once tree size is at least", slog.Uint64("goal", goal))
 			tick := time.NewTicker(1 * time.Second)
 			for {
 				select {
@@ -197,7 +205,7 @@ func main() {
 				case <-tick.C:
 					if tracker.LatestConsistent.Size >= goal {
 						elapsed := time.Since(startTime)
-						klog.Infof("Reached tree size goal of %d after %s; exiting", goal, elapsed)
+						slog.InfoContext(ctx, "Reached tree size goal; exiting", slog.Uint64("goal", goal), slog.Duration("elapsed", elapsed))
 						cancel()
 						return
 					}
@@ -207,13 +215,13 @@ func main() {
 	}
 	if *maxRunTime > 0 {
 		go func() {
-			klog.Infof("Will fail after %s", *maxRunTime)
+			slog.InfoContext(ctx, "Will fail after timeout", slog.Duration("timeout", *maxRunTime))
 			for {
 				select {
 				case <-ctx.Done():
 					return
 				case <-time.After(*maxRunTime):
-					klog.Infof("Max runtime reached; exiting")
+					slog.InfoContext(ctx, "Max runtime reached; exiting")
 					exitCode = 1
 					cancel()
 					return
@@ -327,7 +335,7 @@ func loadIntermediateCACert(path string) (*x509.Certificate, error) {
 		return nil, fmt.Errorf("expected PEM block type 'CERTIFICATE', got '%s'", block.Type)
 	}
 	if len(rest) > 0 {
-		klog.Info("Warning: More than one PEM block found. Parsing only the first.")
+		slog.InfoContext(context.Background(), "Warning: More than one PEM block found. Parsing only the first.")
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
@@ -348,7 +356,8 @@ func publicKey(privKey any) any {
 	case *ed25519.PrivateKey:
 		return k.Public()
 	default:
-		klog.Fatalf("Unknown private key type: %T", privKey)
+		slog.ErrorContext(context.Background(), "Unknown private key type", slog.String("type", fmt.Sprintf("%T", privKey)))
+		os.Exit(1)
 		return nil // Or panic, or return an error
 	}
 }
@@ -417,14 +426,16 @@ func mustCreateReaders(ctx context.Context, us []string) loadtest.LogReader {
 		}
 		rURL, err := url.Parse(u)
 		if err != nil {
-			klog.Exitf("Invalid log reader URL %q: %v", u, err)
+			slog.ErrorContext(ctx, "Invalid log reader URL", slog.String("url", u), slog.Any("error", err))
+			os.Exit(1)
 		}
 
 		switch rURL.Scheme {
 		case "http", "https":
 			c, err := client.NewHTTPFetcher(rURL, hc)
 			if err != nil {
-				klog.Exitf("Failed to create HTTP fetcher for %q: %v", u, err)
+				slog.ErrorContext(ctx, "Failed to create HTTP fetcher", slog.String("url", u), slog.Any("error", err))
+				os.Exit(1)
 			}
 			c.EnableRetries(5)
 			if *bearerToken != "" {
@@ -436,11 +447,13 @@ func mustCreateReaders(ctx context.Context, us []string) loadtest.LogReader {
 		case "gs":
 			c, err := gcp.NewGSFetcher(ctx, rURL.Host, nil)
 			if err != nil {
-				klog.Exitf("NewGSFetcher: %v", err)
+				slog.ErrorContext(ctx, "NewGSFetcher", slog.Any("error", err))
+				os.Exit(1)
 			}
 			r = append(r, c)
 		default:
-			klog.Exitf("Unsupported scheme %s on log URL", rURL.Scheme)
+			slog.ErrorContext(ctx, "Unsupported scheme on log URL", slog.String("scheme", rURL.Scheme))
+			os.Exit(1)
 		}
 	}
 	return loadtest.NewRoundRobinReader(r)
@@ -455,7 +468,8 @@ func mustCreateWriters(us []string) loadtest.LeafWriter {
 		u += "ct/v1/add-chain"
 		wURL, err := url.Parse(u)
 		if err != nil {
-			klog.Exitf("Invalid log writer URL %q: %v", u, err)
+			slog.ErrorContext(context.Background(), "Invalid log writer URL", slog.String("url", u), slog.Any("error", err))
+			os.Exit(1)
 		}
 		w = append(w, httpWriter(wURL, hc, *bearerTokenWrite))
 	}
@@ -464,7 +478,9 @@ func mustCreateWriters(us []string) loadtest.LeafWriter {
 
 func httpWriter(u *url.URL, hc *http.Client, bearerToken string) loadtest.LeafWriter {
 	cTrace := &httptrace.ClientTrace{
-		GotConn: func(info httptrace.GotConnInfo) { klog.Infof("connection established %#v", info) },
+		GotConn: func(info httptrace.GotConnInfo) {
+			slog.InfoContext(context.Background(), "connection established", slog.String("info", fmt.Sprintf("%#v", info)))
+		},
 	}
 	return func(ctx context.Context, newLeaf []byte) (uint64, uint64, error) {
 		req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(newLeaf))
@@ -475,7 +491,7 @@ func httpWriter(u *url.URL, hc *http.Client, bearerToken string) loadtest.LeafWr
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", bearerToken))
 		}
 		reqCtx := req.Context()
-		if klog.V(2).Enabled() {
+		if slog.Default().Enabled(ctx, slog.LevelDebug) {
 			reqCtx = httptrace.WithClientTrace(req.Context(), cTrace)
 		}
 		resp, err := hc.Do(req.WithContext(reqCtx))

--- a/internal/hammer/loadtest/analysis.go
+++ b/internal/hammer/loadtest/analysis.go
@@ -17,10 +17,10 @@ package loadtest
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	movingaverage "github.com/RobinUS2/golang-moving-average"
-	"k8s.io/klog/v2"
 )
 
 func NewHammerAnalyser(treeSizeFn func() uint64) *HammerAnalyser {
@@ -117,11 +117,11 @@ func (a *HammerAnalyser) errorLoop(ctx context.Context) {
 			return
 		case <-tick.C:
 			if pbCount > 0 {
-				klog.Warningf("%d requests received pushback from log", pbCount)
+				slog.WarnContext(ctx, "requests received pushback from log", slog.Int("count", pbCount))
 				pbCount = 0
 			}
 			if lastErrCount > 0 {
-				klog.Warningf("(%d x) %s", lastErrCount, lastErr)
+				slog.WarnContext(ctx, lastErr, slog.Int("count", lastErrCount))
 				lastErrCount = 0
 			}
 		case err := <-a.ErrChan:
@@ -131,7 +131,7 @@ func (a *HammerAnalyser) errorLoop(ctx context.Context) {
 			}
 			es := err.Error()
 			if es != lastErr && lastErrCount > 0 {
-				klog.Warningf("(%d x) %s", lastErrCount, lastErr)
+				slog.WarnContext(ctx, lastErr, slog.Int("count", lastErrCount))
 				lastErr = es
 				lastErrCount = 0
 				continue

--- a/internal/hammer/loadtest/hammer.go
+++ b/internal/hammer/loadtest/hammer.go
@@ -17,12 +17,12 @@ package loadtest
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"os"
 	"time"
 
 	"github.com/transparency-dev/tesseract/internal/client"
 	"github.com/transparency-dev/tesseract/internal/types/rfc6962"
-
-	"k8s.io/klog/v2"
 )
 
 type HammerOpts struct {
@@ -115,17 +115,21 @@ func (h *Hammer) updateCheckpointLoop(ctx context.Context) {
 			size := h.tracker.LatestConsistent.Size
 			_, _, _, err := h.tracker.Update(ctx)
 			if err != nil {
-				klog.Warning(err)
+				slog.WarnContext(ctx, "tracker.Update", slog.Any("error", err))
 				inconsistentErr := client.ErrInconsistency{}
 				if errors.As(err, &inconsistentErr) {
-					klog.Fatalf("Last Good Checkpoint:\n%s\n\nFirst Bad Checkpoint:\n%s\n\n%v", string(inconsistentErr.SmallerRaw), string(inconsistentErr.LargerRaw), inconsistentErr)
+					slog.ErrorContext(ctx, "Inconsistency detected",
+						slog.String("last_good", string(inconsistentErr.SmallerRaw)),
+						slog.String("first_bad", string(inconsistentErr.LargerRaw)),
+						slog.Any("error", inconsistentErr))
+					os.Exit(1)
 				}
 			}
 			newSize := h.tracker.LatestConsistent.Size
 			if newSize > size {
-				klog.V(1).Infof("Updated checkpoint from %d to %d", size, newSize)
+				slog.DebugContext(ctx, "Updated checkpoint", slog.Uint64("from", size), slog.Uint64("to", newSize))
 			} else {
-				klog.V(2).Infof("Checkpoint size unchanged: %d", newSize)
+				slog.DebugContext(ctx, "Checkpoint size unchanged", slog.Uint64("size", newSize))
 			}
 		}
 	}

--- a/internal/hammer/loadtest/tui.go
+++ b/internal/hammer/loadtest/tui.go
@@ -16,15 +16,14 @@ package loadtest
 
 import (
 	"context"
-	"flag"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	movingaverage "github.com/RobinUS2/golang-moving-average"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
-	"k8s.io/klog/v2"
 )
 
 type tuiController struct {
@@ -69,38 +68,32 @@ func NewController(h *Hammer, a *HammerAnalyser) *tuiController {
 
 func (c *tuiController) Run(ctx context.Context) {
 	// Redirect logs to the view
-	if err := flag.Set("logtostderr", "false"); err != nil {
-		klog.Exitf("Failed to set flag: %v", err)
-	}
-	if err := flag.Set("alsologtostderr", "false"); err != nil {
-		klog.Exitf("Failed to set flag: %v", err)
-	}
-	klog.SetOutput(c.logView)
+	slog.SetDefault(slog.New(slog.NewTextHandler(c.logView, &slog.HandlerOptions{Level: slog.LevelInfo})))
 
 	go c.updateStatsLoop(ctx, 500*time.Millisecond)
 
 	c.app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Rune() {
 		case '+':
-			klog.Info("Increasing the read operations per second")
+			slog.InfoContext(ctx, "Increasing the read operations per second")
 			c.hammer.readThrottle.Increase()
 		case '-':
-			klog.Info("Decreasing the read operations per second")
+			slog.InfoContext(ctx, "Decreasing the read operations per second")
 			c.hammer.readThrottle.Decrease()
 		case '>':
-			klog.Info("Increasing the write operations per second")
+			slog.InfoContext(ctx, "Increasing the write operations per second")
 			c.hammer.writeThrottle.Increase()
 		case '<':
-			klog.Info("Decreasing the write operations per second")
+			slog.InfoContext(ctx, "Decreasing the write operations per second")
 			c.hammer.writeThrottle.Decrease()
 		case 'w':
-			klog.Info("Increasing the number of workers")
+			slog.InfoContext(ctx, "Increasing the number of workers")
 			c.hammer.randomReaders.Grow(ctx)
 			c.hammer.fullReaders.Grow(ctx)
 			c.hammer.writers.Grow(ctx)
 			c.hammer.mmdVerifiers.Grow(ctx)
 		case 'W':
-			klog.Info("Decreasing the number of workers")
+			slog.InfoContext(ctx, "Decreasing the number of workers")
 			c.hammer.randomReaders.Shrink(ctx)
 			c.hammer.fullReaders.Shrink(ctx)
 			c.hammer.writers.Shrink(ctx)

--- a/internal/hammer/loadtest/workers.go
+++ b/internal/hammer/loadtest/workers.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand/v2"
 	"time"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/transparency-dev/tesseract/internal/client"
 	"github.com/transparency-dev/tesseract/internal/types/rfc6962"
 	"github.com/transparency-dev/tesseract/internal/x509util"
-	"k8s.io/klog/v2"
 )
 
 // LeafWriter is the signature of a function which can write arbitrary data to a log.
@@ -93,7 +93,7 @@ func (r *LeafReader) Run(ctx context.Context) {
 		if i >= size {
 			continue
 		}
-		klog.V(2).Infof("LeafReader getting %d", i)
+		slog.DebugContext(ctx, "LeafReader getting", slog.Uint64("index", i))
 		_, err := r.getLeaf(ctx, i, size)
 		if err != nil {
 			r.errChan <- fmt.Errorf("failed to get leaf %d: %v", i, err)
@@ -107,7 +107,7 @@ func (r *LeafReader) getLeaf(ctx context.Context, i uint64, logSize uint64) ([]b
 		return nil, fmt.Errorf("requested leaf %d >= log size %d", i, logSize)
 	}
 	if cached, _ := r.c.get(i); cached != nil {
-		klog.V(2).Infof("Using cached result for index %d", i)
+		slog.DebugContext(ctx, "Using cached result", slog.Uint64("index", i))
 		return cached, nil
 	}
 
@@ -230,7 +230,7 @@ func (w *LogWriter) Run(ctx context.Context) {
 		}
 		reqBody, err := json.Marshal(newLeaf)
 		if err != nil {
-			klog.Errorf("Failed to json.Marshal add chain request body: %v", err)
+			slog.ErrorContext(ctx, "Failed to json.Marshal add chain request body", slog.Any("error", err))
 			continue
 		}
 
@@ -260,11 +260,11 @@ func (w *LogWriter) Run(ctx context.Context) {
 			case w.leafMMDChan <- LeafMMD{chain, index, timestamp}:
 			default:
 				// Drop if leafMMDChan is full. This could happen if the MMD verifiers are falling behind.
-				klog.V(3).Infof("leafMMDChan is full: dropping leaf index: %d", index)
+				slog.DebugContext(ctx, "leafMMDChan is full: dropping leaf", slog.Uint64("index", index))
 			}
 		}
 
-		klog.V(2).Infof("Wrote leaf at index %d", index)
+		slog.DebugContext(ctx, "Wrote leaf", slog.Uint64("index", index))
 		newLeaf = w.gen()
 	}
 }

--- a/internal/hammer/testdata/gen.go
+++ b/internal/hammer/testdata/gen.go
@@ -23,12 +23,11 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"os"
 	"path"
 	"time"
-
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -42,51 +41,60 @@ var (
 )
 
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
 	// Generate a new RSA root CA private key.
 	rootPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		klog.Fatalf("Failed to generate root CA private key: %v", err)
+		slog.Error("Failed to generate root CA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveRSAPrivateKeyPEM(rootPrivKey, path.Join(*outputPath, "test_root_ca_private_key.pem")); err != nil {
-		klog.Fatalf("Failed to save root CA private key: %v", err)
+		slog.Error("Failed to save root CA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Generate a new root CA certificate.
 	rootCert, err := rootCACert(rootPrivKey)
 	if err != nil {
-		klog.Fatalf("Failed to generate root CA certificate: %v", err)
+		slog.Error("Failed to generate root CA certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveCertificatePEM(rootCert, path.Join(*outputPath, "test_root_ca_cert.pem")); err != nil {
-		klog.Fatalf("Failed to save root CA certificate: %v", err)
+		slog.Error("Failed to save root CA certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Generate a new RSA intermediate CA private key.
 	intermediatePrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		klog.Fatalf("Failed to generate intermediate CA private key: %v", err)
+		slog.Error("Failed to generate intermediate CA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveRSAPrivateKeyPEM(intermediatePrivKey, path.Join(*outputPath, "test_intermediate_ca_private_key.pem")); err != nil {
-		klog.Fatalf("Failed to save intermediate CA private key: %v", err)
+		slog.Error("Failed to save intermediate CA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Generate a new Intermediate CA certificate.
 	intermediateCert, err := intermediateCACert(rootCert, rootPrivKey, intermediatePrivKey)
 	if err != nil {
-		klog.Fatalf("Failed to generate intermediate CA certificate: %v", err)
+		slog.Error("Failed to generate intermediate CA certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveCertificatePEM(intermediateCert, path.Join(*outputPath, "test_intermediate_ca_cert.pem")); err != nil {
-		klog.Fatalf("Failed to save intermediate CA certificate: %v", err)
+		slog.Error("Failed to save intermediate CA certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Generate a new RSA leaf certificate signing private key.
 	leafCertPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		klog.Fatalf("Failed to generate leaf certificate signing private key: %v", err)
+		slog.Error("Failed to generate leaf certificate signing private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveRSAPrivateKeyPEM(leafCertPrivateKey, path.Join(*outputPath, "test_leaf_cert_signing_private_key.pem")); err != nil {
-		klog.Fatalf("Failed to save leaf certificate signing private key: %v", err)
+		slog.Error("Failed to save leaf certificate signing private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 }
 

--- a/internal/testdata/gen/gen.go
+++ b/internal/testdata/gen/gen.go
@@ -26,13 +26,12 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"os"
 	"path"
 	"strings"
 	"time"
-
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -59,46 +58,54 @@ var (
 )
 
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
 	notBefore, err := parseTime(*notBeforeString)
 	if err != nil {
-		klog.Fatalf("Failed to parse start time: %v", err)
+		slog.Error("Failed to parse start time", slog.Any("error", err))
+		os.Exit(1)
 	}
 	// Generate root.
 	// Generate a new EC root CA private key.
 	rootPrivKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		klog.Fatalf("Failed to generate root CA private key: %v", err)
+		slog.Error("Failed to generate root CA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveECDSAPrivateKeyPEM(rootPrivKey, path.Join(*outputPath, "test_root_ca_private_key.pem")); err != nil {
-		klog.Fatalf("Failed to save root CA private key: %v", err)
+		slog.Error("Failed to save root CA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Generate a new root CA certificate.
 	rootCert, err := rootCACert(rootPrivKey, *notBefore)
 	if err != nil {
-		klog.Fatalf("Failed to generate root CA certificate: %v", err)
+		slog.Error("Failed to generate root CA certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveCertificatePEM(rootCert, path.Join(*outputPath, "test_root_ca_cert.pem")); err != nil {
-		klog.Fatalf("Failed to save root CA certificate: %v", err)
+		slog.Error("Failed to save root CA certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Generate CT server private keys (ECDSA, RSA).
 	ctServerECDSAPrivKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		klog.Fatalf("Failed to generate CT server ECDSA private key: %v", err)
+		slog.Error("Failed to generate CT server ECDSA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveECDSAPrivateKeyPEM(ctServerECDSAPrivKey, path.Join(*outputPath, "test_ct_server_ecdsa_private_key.pem")); err != nil {
-		klog.Fatalf("Failed to save CT server ECDSA private key: %v", err)
+		slog.Error("Failed to save CT server ECDSA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	ctServerRSAPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		klog.Fatalf("Failed to generate CT server RSA private key: %v", err)
+		slog.Error("Failed to generate CT server RSA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveRSAPrivateKeyPEM(ctServerRSAPrivKey, path.Join(*outputPath, "test_ct_server_rsa_private_key.pem")); err != nil {
-		klog.Fatalf("Failed to save CT server RSA private key: %v", err)
+		slog.Error("Failed to save CT server RSA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	genLeaves(rootCert, rootPrivKey, *notBefore)
@@ -112,26 +119,32 @@ func genLeaves(rootCert *x509.Certificate, rootPrivKey *ecdsa.PrivateKey, notBef
 	// Generate a new ECDSA leaf certificate signing private key.
 	leafCertPrivateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		klog.Fatalf("Failed to generate leaf certificate signing private key: %v", err)
+		slog.Error("Failed to generate leaf certificate signing private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveECDSAPrivateKeyPEM(leafCertPrivateKey, path.Join(*outputPath, "test_leaf_signed_by_root_signing_private_key.pem")); err != nil {
-		klog.Fatalf("Failed to save leaf certificate signing private key: %v", err)
+		slog.Error("Failed to save leaf certificate signing private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	chainGenerator := newChainGenerator(rootCert, rootPrivKey, leafCertPrivateKey.Public())
 	leafCert, err := chainGenerator.certificate(100, false, notBefore)
 	if err != nil {
-		klog.Fatalf("Failed to generate leaf certificate: %v", err)
+		slog.Error("Failed to generate leaf certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveCertificatePEM(leafCert, path.Join(*outputPath, "test_leaf_cert_signed_by_root.pem")); err != nil {
-		klog.Fatalf("Failed to save leaf cert: %v", err)
+		slog.Error("Failed to save leaf cert", slog.Any("error", err))
+		os.Exit(1)
 	}
 	leafPreCert, err := chainGenerator.certificate(200, true, notBefore)
 	if err != nil {
-		klog.Fatalf("Failed to generate leaf certificate: %v", err)
+		slog.Error("Failed to generate leaf certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveCertificatePEM(leafPreCert, path.Join(*outputPath, "test_leaf_pre_cert_signed_by_root.pem")); err != nil {
-		klog.Fatalf("Failed to save leaf cert: %v", err)
+		slog.Error("Failed to save leaf cert", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 }
@@ -141,44 +154,54 @@ func genIntermediateAndLeaves(rootCert *x509.Certificate, rootPrivKey *ecdsa.Pri
 	// Generate a new ECDSA intermediate CA private key.
 	intermediatePrivKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		klog.Fatalf("Failed to generate intermediate CA private key: %v", err)
+		slog.Error("Failed to generate intermediate CA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveECDSAPrivateKeyPEM(intermediatePrivKey, path.Join(*outputPath, "test_intermediate_ca_private_key.pem")); err != nil {
-		klog.Fatalf("Failed to save intermediate CA private key: %v", err)
+		slog.Error("Failed to save intermediate CA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Generate a new intermediate CA certificate with CT extension.
 	intermediateCert, err := intermediateCACert(rootCert, rootPrivKey, intermediatePrivKey, false, notBefore)
 	if err != nil {
-		klog.Fatalf("Failed to generate intermediate CA certificate: %v", err)
+		slog.Error("Failed to generate intermediate CA certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveCertificatePEM(intermediateCert, path.Join(*outputPath, "test_intermediate_ca_cert.pem")); err != nil {
-		klog.Fatalf("Failed to save intermediate CA certificate: %v", err)
+		slog.Error("Failed to save intermediate CA certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Generate a new ECDSA leaf certificate signing private key.
 	leafCertPrivateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		klog.Fatalf("Failed to generate leaf certificate signing private key: %v", err)
+		slog.Error("Failed to generate leaf certificate signing private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveECDSAPrivateKeyPEM(leafCertPrivateKey, path.Join(*outputPath, "test_leaf_signed_by_intermediate_signing_private_key.pem")); err != nil {
-		klog.Fatalf("Failed to save leaf certificate signing private key: %v", err)
+		slog.Error("Failed to save leaf certificate signing private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	chainGenerator := newChainGenerator(intermediateCert, intermediatePrivKey, leafCertPrivateKey.Public())
 	leafCert, err := chainGenerator.certificate(100, false, notBefore)
 	if err != nil {
-		klog.Fatalf("Failed to generate leaf certificate: %v", err)
+		slog.Error("Failed to generate leaf certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveCertificatePEM(leafCert, path.Join(*outputPath, "test_leaf_cert_signed_by_intermediate.pem")); err != nil {
-		klog.Fatalf("Failed to save leaf cert: %v", err)
+		slog.Error("Failed to save leaf cert", slog.Any("error", err))
+		os.Exit(1)
 	}
 	leafPreCert, err := chainGenerator.certificate(200, true, notBefore)
 	if err != nil {
-		klog.Fatalf("Failed to generate leaf pre-certificate: %v", err)
+		slog.Error("Failed to generate leaf pre-certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveCertificatePEM(leafPreCert, path.Join(*outputPath, "test_leaf_pre_cert_signed_by_intermediate.pem")); err != nil {
-		klog.Fatalf("Failed to save leaf pre-cert: %v", err)
+		slog.Error("Failed to save leaf pre-cert", slog.Any("error", err))
+		os.Exit(1)
 	}
 }
 
@@ -188,44 +211,54 @@ func genPreIssuerAndLeaves(rootCert *x509.Certificate, rootPrivKey *ecdsa.Privat
 	// Generate a new ECDSA intermediate CA private key.
 	preIntermediatePrivKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		klog.Fatalf("Failed to generate intermediate CA private key: %v", err)
+		slog.Error("Failed to generate intermediate CA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveECDSAPrivateKeyPEM(preIntermediatePrivKey, path.Join(*outputPath, "test_pre_intermediate_ca_private_key.pem")); err != nil {
-		klog.Fatalf("Failed to save intermediate CA private key: %v", err)
+		slog.Error("Failed to save intermediate CA private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Generate a new intermediate CA certificate with CT extension.
 	preIntermediateCert, err := intermediateCACert(rootCert, rootPrivKey, preIntermediatePrivKey, true, notBefore)
 	if err != nil {
-		klog.Fatalf("Failed to generate intermediate CA certificate: %v", err)
+		slog.Error("Failed to generate intermediate CA certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveCertificatePEM(preIntermediateCert, path.Join(*outputPath, "test_pre_intermediate_ca_cert.pem")); err != nil {
-		klog.Fatalf("Failed to save intermediate CA certificate: %v", err)
+		slog.Error("Failed to save intermediate CA certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	// Generate a new ECDSA leaf certificate signing private key.
 	leafCertPrivateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		klog.Fatalf("Failed to generate leaf certificate signing private key: %v", err)
+		slog.Error("Failed to generate leaf certificate signing private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveECDSAPrivateKeyPEM(leafCertPrivateKey, path.Join(*outputPath, "test_leaf_signed_by_pre_intermediate_signing_private_key.pem")); err != nil {
-		klog.Fatalf("Failed to save leaf certificate signing private key: %v", err)
+		slog.Error("Failed to save leaf certificate signing private key", slog.Any("error", err))
+		os.Exit(1)
 	}
 
 	chainGenerator := newChainGenerator(preIntermediateCert, preIntermediatePrivKey, leafCertPrivateKey.Public())
 	leafCert, err := chainGenerator.certificate(100, false, notBefore)
 	if err != nil {
-		klog.Fatalf("Failed to generate leaf certificate: %v", err)
+		slog.Error("Failed to generate leaf certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveCertificatePEM(leafCert, path.Join(*outputPath, "test_leaf_cert_signed_by_pre_intermediate.pem")); err != nil {
-		klog.Fatalf("Failed to save leaf cert: %v", err)
+		slog.Error("Failed to save leaf cert", slog.Any("error", err))
+		os.Exit(1)
 	}
 	leafPreCert, err := chainGenerator.certificate(200, true, notBefore)
 	if err != nil {
-		klog.Fatalf("Failed to generate leaf certificate: %v", err)
+		slog.Error("Failed to generate leaf certificate", slog.Any("error", err))
+		os.Exit(1)
 	}
 	if err := saveCertificatePEM(leafPreCert, path.Join(*outputPath, "test_leaf_pre_cert_signed_by_pre_intermediate.pem")); err != nil {
-		klog.Fatalf("Failed to save leaf cert: %v", err)
+		slog.Error("Failed to save leaf cert", slog.Any("error", err))
+		os.Exit(1)
 	}
 }
 

--- a/internal/x509util/pem_cert_pool.go
+++ b/internal/x509util/pem_cert_pool.go
@@ -15,17 +15,18 @@
 package x509util
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"sync"
 
 	"github.com/transparency-dev/tesseract/internal/lax509"
-	"k8s.io/klog/v2"
 )
 
 // String for certificate blocks in BEGIN / END PEM headers
@@ -82,7 +83,7 @@ func (p *PEMCertPool) AddCerts(certs []*x509.Certificate) int {
 	for _, cert := range certs {
 		fingerprint := sha256.Sum256(cert.Raw)
 		if _, exists := p.rejectedFingerprints[fingerprint]; exists {
-			klog.Warningf("Rejecting certificate with fingerprint %x", fingerprint)
+			slog.WarnContext(context.Background(), "Rejecting certificate", slog.String("fingerprint", hex.EncodeToString(fingerprint[:])))
 			continue
 		}
 		_, ok := p.fingerprintToCertMap[fingerprint]
@@ -133,7 +134,7 @@ func (p *PEMCertPool) AppendCertsFromPEMs(pems ...[]byte) (parsed, added int) {
 			cert, err := x509.ParseCertificate(block.Bytes)
 			if err != nil {
 				crtsh := fmt.Sprintf("https://crt.sh/?sha256=%x", sha256.Sum256(block.Bytes))
-				klog.Warningf("error parsing PEM certificate %s: %v", crtsh, err)
+				slog.WarnContext(context.Background(), "error parsing PEM certificate", slog.String("crtsh", crtsh), slog.Any("error", err))
 				continue
 			}
 

--- a/storage/aws/issuers.go
+++ b/storage/aws/issuers.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"path"
 	"strings"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/transparency-dev/tesseract/internal/types/staticct"
 	"github.com/transparency-dev/tesseract/storage"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/klog/v2"
 )
 
 // IssuersStorage is a key value store backed by S3 on AWS to store issuer chains.
@@ -129,7 +129,7 @@ func (s *IssuersStorage) LoadAll(ctx context.Context) ([]storage.KV, error) {
 
 			data, err := io.ReadAll(resp.Body)
 			if errC := resp.Body.Close(); errC != nil {
-				klog.Errorf("resp.Body.Close(): %v", errC)
+				slog.ErrorContext(ctx, "resp.Body.Close()", slog.Any("error", errC))
 			}
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to read object body %q: %w", *obj.Key, err))
@@ -172,7 +172,7 @@ func (s *IssuersStorage) AddIfNotExist(ctx context.Context, kv []storage.KV) err
 					}
 					defer func() {
 						if err := existingObj.Body.Close(); err != nil {
-							klog.Errorf("existingObj.Body.Close(): %v", err)
+							slog.ErrorContext(ctx, "existingObj.Body.Close()", slog.Any("error", err))
 						}
 					}()
 					existing, err := io.ReadAll(existingObj.Body)
@@ -180,14 +180,14 @@ func (s *IssuersStorage) AddIfNotExist(ctx context.Context, kv []storage.KV) err
 						return fmt.Errorf("failed to read object %q: %v", objName, err)
 					}
 					if !bytes.Equal(existing, kv.V) {
-						klog.Errorf("Resource %q non-idempotent write:\n%s", objName, cmp.Diff(existing, kv.V))
+						slog.ErrorContext(ctx, "Resource non-idempotent write", slog.String("name", objName), slog.String("diff", cmp.Diff(existing, kv.V)))
 						return fmt.Errorf("precondition failed: resource content for %q differs from data to-be-written", objName)
 					}
 					return nil
 				}
 				return fmt.Errorf("failed to write object %q to bucket %q: %w", objName, s.bucket, err)
 			}
-			klog.Infof("AddIfNotExist: added %q in bucket %q", objName, s.bucket)
+			slog.InfoContext(ctx, "AddIfNotExist: added", slog.String("name", objName), slog.String("bucket", s.bucket))
 			return nil
 		})
 	}

--- a/storage/gcp/issuers.go
+++ b/storage/gcp/issuers.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"path"
 	"strings"
@@ -33,7 +34,6 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/klog/v2"
 )
 
 // IssuersStorage is a key value store backed by GCS on GCP to store issuer chains.
@@ -106,7 +106,7 @@ func (s *IssuersStorage) LoadAll(ctx context.Context) ([]storage.KV, error) {
 
 		root, err := io.ReadAll(r)
 		if errC := r.Close(); errC != nil {
-			klog.Errorf("r.Close(): %v", errC)
+			slog.ErrorContext(ctx, "r.Close()", slog.Any("error", errC))
 		}
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to read object %q: %v", attr.Name, err))
@@ -151,7 +151,7 @@ func (s *IssuersStorage) AddIfNotExist(ctx context.Context, kv []storage.KV) err
 					}
 					defer func() {
 						if err := r.Close(); err != nil {
-							klog.Errorf("r.Close(): %v", err)
+							slog.ErrorContext(ctx, "r.Close()", slog.Any("error", err))
 						}
 					}()
 
@@ -161,17 +161,17 @@ func (s *IssuersStorage) AddIfNotExist(ctx context.Context, kv []storage.KV) err
 					}
 
 					if !bytes.Equal(existing, kv.V) {
-						klog.Errorf("Resource %q non-idempotent write:\n%s", objName, cmp.Diff(existing, kv.V))
+						slog.ErrorContext(ctx, "Resource non-idempotent write", slog.String("name", objName), slog.String("diff", cmp.Diff(existing, kv.V)))
 						return fmt.Errorf("precondition failed: resource content for %q differs from data to-be-written", objName)
 					}
-					klog.V(2).Infof("AddIssuersIfNotExist: object %q with same data already exists in bucket %q, continuing", objName, s.bucket.BucketName())
+					slog.DebugContext(ctx, "AddIssuersIfNotExist: object with same data already exists, continuing", slog.String("name", objName), slog.String("bucket", s.bucket.BucketName()))
 					return nil
 				}
 
 				return fmt.Errorf("failed to close write on %q: %v", objName, err)
 			}
 
-			klog.Infof("AddIfNotExist: added %q in bucket %q", objName, s.bucket.BucketName())
+			slog.InfoContext(ctx, "AddIfNotExist: added", slog.String("name", objName), slog.String("bucket", s.bucket.BucketName()))
 			return nil
 		})
 	}

--- a/storage/posix/file_ops.go
+++ b/storage/posix/file_ops.go
@@ -15,16 +15,16 @@
 package posix
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
-
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -120,7 +120,7 @@ func createEx(name string, d []byte) error {
 		}
 		defer func() {
 			if err := os.Remove(tmpName); err != nil {
-				klog.Warningf("Failed to remove temporary file %q: %v", tmpName, err)
+				slog.WarnContext(context.Background(), "Failed to remove temporary file", slog.String("name", tmpName), slog.Any("error", err))
 			}
 		}()
 

--- a/storage/posix/issuers.go
+++ b/storage/posix/issuers.go
@@ -19,13 +19,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/transparency-dev/tesseract/internal/types/staticct"
 	"github.com/transparency-dev/tesseract/storage"
-	"k8s.io/klog/v2"
 )
 
 // IssuersStorage is a key value store backed by files to store issuer chains.
@@ -109,7 +109,7 @@ func (s *IssuersStorage) AddIfNotExist(ctx context.Context, kv []storage.KV) err
 			errs = append(errs, err)
 			continue
 		}
-		klog.Infof("AddIfNotExist: added %q in %q", string(kv.K), s.dir)
+		slog.InfoContext(ctx, "AddIfNotExist: added", slog.String("key", string(kv.K)), slog.String("dir", s.dir))
 	}
 	return errors.Join(errs...)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"sync"
@@ -32,7 +33,6 @@ import (
 	"github.com/transparency-dev/tessera/ctonly"
 	"github.com/transparency-dev/tesseract/internal/types/staticct"
 	"golang.org/x/mod/sumdb/note"
-	"k8s.io/klog/v2"
 )
 
 // CreateStorage instantiates a Tessera storage implementation with a signer option.
@@ -181,7 +181,7 @@ func cachedStoreIssuers(s IssuerStorage) func(context.Context, []KV) error {
 			_, ok := m[string(kv.K)]
 			mu.RUnlock()
 			if ok {
-				klog.V(2).Infof("cachedStoreIssuers wrapper: found %q in local key cache", kv.K)
+				slog.DebugContext(ctx, "cachedStoreIssuers wrapper: found in local key cache", slog.String("key", string(kv.K)))
 				continue
 			}
 			req = append(req, kv)
@@ -191,7 +191,7 @@ func cachedStoreIssuers(s IssuerStorage) func(context.Context, []KV) error {
 		}
 		for _, kv := range req {
 			if len(m) >= maxCachedIssuerKeys {
-				klog.V(2).Infof("cachedStoreIssuers wrapper: local issuer cache full, will stop caching issuers.")
+				slog.DebugContext(ctx, "cachedStoreIssuers wrapper: local issuer cache full, will stop caching issuers.")
 				return nil
 			}
 			mu.Lock()


### PR DESCRIPTION
Migrates all logging call sites from k8s.io/klog/v2 to log/slog. Each binary now configures slog.SetDefault with a text handler keyed off a new --slog_level flag (the GCP server keeps its existing Cloud Logging exporter wiring). klog.V(N) call sites collapse to slog.Debug, and klog.Exitf/Fatalf are replaced with slog.Error + os.Exit(1).

Adds golangci-lint config enforcing sloglint (attr-only, context: all) and a depguard rule denying further klog imports.

Towards #416.