### PR TITLE
[Logging] More granular debug logging levels

### DIFF
--- a/cmd/experimental/fetch_roots/main.go
+++ b/cmd/experimental/fetch_roots/main.go
@@ -31,7 +31,7 @@ import (
 var (
 	url            = flag.String("url", "https://ccadb.my.salesforce-sites.com/ccadb/RootCACertificatesIncludedByRSReportCSV", "URL to fetch the CSV from.")
 	outputFilename = flag.String("output_filename", "roots.pem", "Path of the output file.")
-	slogLevel      = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See Logging section in cmd/tesseract/README.md.")
+	slogLevel      = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See cmd/tesseract/README.md#Logging.")
 )
 
 var (

--- a/cmd/experimental/fetch_roots/main.go
+++ b/cmd/experimental/fetch_roots/main.go
@@ -31,7 +31,7 @@ import (
 var (
 	url            = flag.String("url", "https://ccadb.my.salesforce-sites.com/ccadb/RootCACertificatesIncludedByRSReportCSV", "URL to fetch the CSV from.")
 	outputFilename = flag.String("output_filename", "roots.pem", "Path of the output file.")
-	slogLevel      = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
+	slogLevel      = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See Logging section in cmd/tesseract/README.md.")
 )
 
 var (

--- a/cmd/fsck/main.go
+++ b/cmd/fsck/main.go
@@ -52,7 +52,7 @@ var (
 	userAgentInfo    = flag.String("user_agent_info", "", "Optional string to append to the user agent (e.g. email address for Sunlight logs)")
 	bundleCompressed = flag.Bool("bundle_compressed", false, "Enable decompression of entry bundles, useful for Sunlight logs")
 	ui               = flag.Bool("ui", true, "Set to true to use a TUI to display progress, or false for logging")
-	slogLevel        = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See Logging section in cmd/tesseract/README.md.")
+	slogLevel        = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See cmd/tesseract/README.md#Logging.")
 )
 
 const (

--- a/cmd/fsck/main.go
+++ b/cmd/fsck/main.go
@@ -36,7 +36,9 @@ import (
 	"github.com/transparency-dev/tessera/fsck"
 	"github.com/transparency-dev/tesseract/cmd/fsck/internal/tui"
 	"github.com/transparency-dev/tesseract/internal/client"
+	"github.com/transparency-dev/tesseract/internal/logger"
 	"golang.org/x/crypto/cryptobyte"
+
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/sync/errgroup"
 )
@@ -50,7 +52,7 @@ var (
 	userAgentInfo    = flag.String("user_agent_info", "", "Optional string to append to the user agent (e.g. email address for Sunlight logs)")
 	bundleCompressed = flag.Bool("bundle_compressed", false, "Enable decompression of entry bundles, useful for Sunlight logs")
 	ui               = flag.Bool("ui", true, "Set to true to use a TUI to display progress, or false for logging")
-	slogLevel        = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
+	slogLevel        = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See Logging section in cmd/tesseract/README.md.")
 )
 
 const (
@@ -163,7 +165,7 @@ func (l *logStateCollector) checkIssuersTask(ctx context.Context, readIssuer fun
 					errC <- fmt.Errorf("couldn't fetch issuer for %x: %v", fp, err)
 					continue
 				}
-				slog.DebugContext(ctx, "Issuer is present", slog.String("fp", fmt.Sprintf("%x", fp)))
+				logger.DebugExtraContext(ctx, "Issuer is present", slog.String("fp", fmt.Sprintf("%x", fp)))
 			}
 		}()
 	}
@@ -185,7 +187,7 @@ func (l *logStateCollector) addIssuers(fpRaw cryptobyte.String) {
 		fp, fpRaw = fpRaw[:32], fpRaw[32:]
 		_, existed := l.issuersSeen.LoadOrStore(string(fp), true)
 		if !existed {
-			slog.DebugContext(context.Background(), "Found issuer", slog.String("fp", fmt.Sprintf("%x", fp)))
+			logger.DebugExtraContext(context.Background(), "Found issuer", slog.String("fp", fmt.Sprintf("%x", fp)))
 			l.issuersToCheck <- fp
 		}
 	}

--- a/cmd/tesseract/README.md
+++ b/cmd/tesseract/README.md
@@ -295,3 +295,16 @@ being used.
 To run multiple logs, run multiple TesseraCT instances configured with different
 Tessera resources. For simplicity, it is not possible to serve multiple logs
 from a single TesseraCT instance.
+
+### Logging
+
+TesseraCT uses `slog` for its structured logging. The `--slog_level` command-line flag allows you to configure the verbosity threshold of log messages. It mostly follows the standard levels defined in [slog.Level](https://pkg.go.dev/log/slog#Level), but it also introduces repository-specific custom debug levels:
+
+| Level Value | Level Name | Purpose |
+| :--- | :--- | :--- |
+| `8` | `ERROR` | Application errors that require immediate attention. |
+| `4` | `WARN` | Warnings for recoverable errors. |
+| `0` | `INFO` | High-level and default informational messages. |
+| `-4` | `DEBUG` | General debugging logs (formerly `klog.V(1)`). |
+| `-8` | `DEBUG_EXTRA` | More granular and frequent debugging logs (formerly `klog.V(2)` and `klog.V(3)`). |
+| `-12` | `EXTREME` | Extremely verbose logging, intended for deep dives (formerly `klog.V(4+)`). |

--- a/cmd/tesseract/README.md
+++ b/cmd/tesseract/README.md
@@ -300,11 +300,11 @@ from a single TesseraCT instance.
 
 TesseraCT uses `slog` for its structured logging. The `--slog_level` command-line flag allows you to configure the verbosity threshold of log messages. It mostly follows the standard levels defined in [slog.Level](https://pkg.go.dev/log/slog#Level), but it also introduces repository-specific custom debug levels:
 
-| Level Value | Level Name | Purpose |
-| :--- | :--- | :--- |
-| `8` | `ERROR` | Application errors that require immediate attention. |
-| `4` | `WARN` | Warnings for recoverable errors. |
-| `0` | `INFO` | High-level and default informational messages. |
-| `-4` | `DEBUG` | General debugging logs (formerly `klog.V(1)`). |
-| `-8` | `DEBUG_EXTRA` | More granular and frequent debugging logs (formerly `klog.V(2)` and `klog.V(3)`). |
-| `-12` | `EXTREME` | Extremely verbose logging, intended for deep dives (formerly `klog.V(4+)`). |
+| Level Value | Level Name    | Purpose |
+| ----------- | ------------- | ------- |
+| `8`         | `ERROR`       | Application errors that require immediate attention. |
+| `4`         | `WARN`        | Warnings for recoverable errors. |
+| `0`         | `INFO`        | High-level and default informational messages. |
+| `-4`        | `DEBUG`       | General debugging logs (formerly `klog.V(1)`). |
+| `-8`        | `DEBUG_EXTRA` | More granular and frequent debugging logs (formerly `klog.V(2)` and `klog.V(3)`). |
+| `-12`       | `EXTREME`     | Extremely verbose logging, intended for deep dives (formerly `klog.V(4+)`). |

--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -106,7 +106,7 @@ var (
 	signerPublicKeyFile        = flag.String("signer_public_key_file", "", "Path to public key file for checkpoints and SCTs signer (alternative to secrets manager)")
 	signerPrivateKeyFile       = flag.String("signer_private_key_file", "", "Path to private key file for checkpoints and SCTs signer (alternative to secrets manager)")
 	usePathStyle               = flag.Bool("s3_use_path_style", false, "Whether to force the AWS S3 client to use path-style bucket references, probably only useful for on-prem deployments")
-	slogLevel                  = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
+	slogLevel                  = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See Logging section in cmd/tesseract/README.md.")
 )
 
 // nolint:staticcheck

--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -106,7 +106,7 @@ var (
 	signerPublicKeyFile        = flag.String("signer_public_key_file", "", "Path to public key file for checkpoints and SCTs signer (alternative to secrets manager)")
 	signerPrivateKeyFile       = flag.String("signer_private_key_file", "", "Path to private key file for checkpoints and SCTs signer (alternative to secrets manager)")
 	usePathStyle               = flag.Bool("s3_use_path_style", false, "Whether to force the AWS S3 client to use path-style bucket references, probably only useful for on-prem deployments")
-	slogLevel                  = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See Logging section in cmd/tesseract/README.md.")
+	slogLevel                  = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See cmd/tesseract/README.md#Logging.")
 )
 
 // nolint:staticcheck

--- a/cmd/tesseract/gcp/README.md
+++ b/cmd/tesseract/gcp/README.md
@@ -48,7 +48,7 @@ the format described by https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/mai
 ## Logging
 
 TesseraCT uses Go's `log/slog` for structured logging.
-- **Routing**: By default, `slog` bakes OpenTelemetry trace context and exports logs **directly to the Cloud Logging API** (bypassing `stderr`). The cut-off level can be tuned via `--slog_level` (default `0` = INFO; `-4` = DEBUG).
+- **Routing**: By default, `slog` bakes OpenTelemetry trace context and exports logs **directly to the Cloud Logging API** (bypassing `stderr`). The cut-off level can be tuned via `--slog_level` (default `0` = INFO; `-4` = DEBUG). See the [parent README](../README.md#Logging) for more details.
 - **Expected Fields**: Because it bypasses `stderr` and the Docker `gcplogs` driver, it does not get automatic container/instance decoration by Docker. Instead, at startup, TesseraCT queries the GCE Metadata Server and reads flags to manually bake these fields into the default `slog` logger. You can expect:
   - `message`
   - `severity`

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -112,7 +112,7 @@ var (
 	signerPrivateKeySecretName = flag.String("signer_private_key_secret_name", "", "Private key secret name for checkpoints and SCTs signer. Format: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}.")
 	traceFraction              = flag.Float64("trace_fraction", 0, "Fraction of open-telemetry span traces to sample")
 	otelProjectID              = flag.String("otel_project_id", "", "GCP project ID for OpenTelemetry exporter.")
-	slogLevel                  = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is INFO. See https://pkg.go.dev/log/slog#Level.")
+	slogLevel                  = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See Logging section in cmd/tesseract/README.md.")
 	slogToCloudAPI             = flag.Bool("slog_to_cloud_api", true, "Export logs directly to Cloud Logging API. Required --otel_project_id to be set.")
 	slogToStdOut               = flag.Bool("slog_to_stdout", false, "Export logs to stdout.")
 	containerName              = flag.String("container_name", "", "Name of the running container. Only used to decorate slog events.")

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -112,7 +112,7 @@ var (
 	signerPrivateKeySecretName = flag.String("signer_private_key_secret_name", "", "Private key secret name for checkpoints and SCTs signer. Format: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}.")
 	traceFraction              = flag.Float64("trace_fraction", 0, "Fraction of open-telemetry span traces to sample")
 	otelProjectID              = flag.String("otel_project_id", "", "GCP project ID for OpenTelemetry exporter.")
-	slogLevel                  = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See Logging section in cmd/tesseract/README.md.")
+	slogLevel                  = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See cmd/tesseract/README.md#Logging.")
 	slogToCloudAPI             = flag.Bool("slog_to_cloud_api", true, "Export logs directly to Cloud Logging API. Required --otel_project_id to be set.")
 	slogToStdOut               = flag.Bool("slog_to_stdout", false, "Export logs to stdout.")
 	containerName              = flag.String("container_name", "", "Name of the running container. Only used to decorate slog events.")

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -108,7 +108,7 @@ var (
 	storageDir    = flag.String("storage_dir", "", "Path to root of log storage.")
 	privKeyFile   = flag.String("private_key", "", "Location of private key file. If unset, uses the contents of the LOG_PRIVATE_KEY environment variable.")
 	traceFraction = flag.Float64("trace_fraction", 0, "Fraction of open-telemetry span traces to sample")
-	slogLevel     = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
+	slogLevel     = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See Logging section in cmd/tesseract/README.md.")
 )
 
 func main() {

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -108,7 +108,7 @@ var (
 	storageDir    = flag.String("storage_dir", "", "Path to root of log storage.")
 	privKeyFile   = flag.String("private_key", "", "Location of private key file. If unset, uses the contents of the LOG_PRIVATE_KEY environment variable.")
 	traceFraction = flag.Float64("trace_fraction", 0, "Fraction of open-telemetry span traces to sample")
-	slogLevel     = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See Logging section in cmd/tesseract/README.md.")
+	slogLevel     = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. See cmd/tesseract/README.md#Logging.")
 )
 
 func main() {

--- a/internal/ct/handlers.go
+++ b/internal/ct/handlers.go
@@ -33,7 +33,9 @@ import (
 	"time"
 
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tesseract/internal/logger"
 	"github.com/transparency-dev/tesseract/internal/otel"
+
 	"github.com/transparency-dev/tesseract/internal/types/rfc6962"
 	"github.com/transparency-dev/tesseract/internal/types/tls"
 	"github.com/transparency-dev/tesseract/internal/x509util"
@@ -209,7 +211,7 @@ func (a appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		slog.WarnContext(logCtx, "the request was received on a URL which is not prefixed with the configured origin", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.Any("error", err))
 	}
 
-	slog.DebugContext(logCtx, "request received", slog.String("origin", a.log.origin), slog.String("method", r.Method), slog.String("url", r.URL.String()), slog.String("name", a.name))
+	logger.DebugExtraContext(logCtx, "request received", slog.String("origin", a.log.origin), slog.String("method", r.Method), slog.String("url", r.URL.String()), slog.String("name", a.name))
 	// TODO(phboneff): add a.Method directly on the handler path and remove this test.
 	if r.Method != a.method {
 		slog.WarnContext(logCtx, "wrong HTTP method", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.String("method", r.Method))
@@ -237,7 +239,7 @@ func (a appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	attrs = append(attrs, hattrs...)
 	attrs = append(attrs, codeKey.Int(statusCode))
 	a.opts.RequestLog.status(ctx, statusCode)
-	slog.DebugContext(ctx, "handler response", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.Int("status", statusCode))
+	logger.DebugExtraContext(ctx, "handler response", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.Int("status", statusCode))
 	rspCounter.Add(logCtx, 1, metric.WithAttributes(attrs...))
 	if err != nil {
 		if errors.Is(err, context.Canceled) && errors.Is(r.Context().Err(), context.Canceled) {
@@ -479,7 +481,7 @@ func addChainInternal(ctx context.Context, opts *HandlerOptions, log *log, w htt
 		return http.StatusInternalServerError, nil, fmt.Errorf("failed to store issuer chain: %s", err)
 	}
 
-	slog.DebugContext(ctx, "storage.Add", slog.String("origin", log.origin), slog.String("method", method))
+	logger.DebugExtraContext(ctx, "storage.Add", slog.String("origin", log.origin), slog.String("method", method))
 	future, err := log.storage.Add(ctx, entry)
 	// helper function to return a 429
 	tooManyRequests := func(reason string) (int, []attribute.KeyValue, error) {
@@ -542,7 +544,7 @@ func addChainInternal(ctx context.Context, opts *HandlerOptions, log *log, w htt
 		// reason is logged and http status is already set
 		return http.StatusInternalServerError, nil, fmt.Errorf("failed to write response: %s", err)
 	}
-	slog.DebugContext(ctx, "SCT issued", slog.String("origin", log.origin), slog.String("method", method))
+	logger.DebugExtraContext(ctx, "SCT issued", slog.String("origin", log.origin), slog.String("method", method))
 	if !index.IsDup {
 		lastSCTTimestamp.Record(ctx, otel.Clamp64(sct.Timestamp), metric.WithAttributes(originKey.String(log.origin)))
 		lastSCTIndex.Record(ctx, otel.Clamp64(index.Index), metric.WithAttributes(originKey.String(log.origin)))

--- a/internal/ct/requestlog.go
+++ b/internal/ct/requestlog.go
@@ -19,7 +19,9 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"log/slog"
+	"github.com/transparency-dev/tesseract/internal/logger"
 	"time"
+
 )
 
 // requestLog allows implementations to do structured logging of TesseraCT
@@ -63,25 +65,25 @@ type DefaultRequestLog struct {
 
 // start logs the start of request processing.
 func (dlr *DefaultRequestLog) start(ctx context.Context) context.Context {
-	slog.DebugContext(ctx, "RL: Start")
+	logger.ExtremeContext(ctx, "RL: Start")
 	return ctx
 }
 
 // origin logs the origin of the CT log that this request is for.
 func (dlr *DefaultRequestLog) origin(ctx context.Context, p string) {
-	slog.DebugContext(ctx, "RL: LogOrigin", slog.String("origin", p))
+	logger.ExtremeContext(ctx, "RL: LogOrigin", slog.String("origin", p))
 }
 
 // addDERToChain logs the raw bytes of a submitted certificate.
 func (dlr *DefaultRequestLog) addDERToChain(ctx context.Context, d []byte) {
 	// Explicit hex encoding below to satisfy CodeQL:
-	slog.DebugContext(ctx, "RL: Cert DER", slog.String("der", hex.EncodeToString(d)))
+	logger.ExtremeContext(ctx, "RL: Cert DER", slog.String("der", hex.EncodeToString(d)))
 }
 
 // addCertToChain logs some issuer / subject / timing fields from a
 // certificate that is part of a submitted chain.
 func (dlr *DefaultRequestLog) addCertToChain(ctx context.Context, cert *x509.Certificate) {
-	slog.DebugContext(ctx, "RL: Cert",
+	logger.ExtremeContext(ctx, "RL: Cert",
 		slog.String("subject", cert.Subject.String()),
 		slog.String("issuer", cert.Issuer.String()),
 		slog.String("not_before", cert.NotBefore.Format(time.RFC1123Z)),
@@ -90,10 +92,10 @@ func (dlr *DefaultRequestLog) addCertToChain(ctx context.Context, cert *x509.Cer
 
 // issueSCT logs an SCT that will be issued to a client.
 func (dlr *DefaultRequestLog) issueSCT(ctx context.Context, sct []byte) {
-	slog.DebugContext(ctx, "RL: Issuing SCT", slog.String("sct", hex.EncodeToString(sct)))
+	logger.ExtremeContext(ctx, "RL: Issuing SCT", slog.String("sct", hex.EncodeToString(sct)))
 }
 
 // status logs the response HTTP status code after processing completes.
 func (dlr *DefaultRequestLog) status(ctx context.Context, s int) {
-	slog.DebugContext(ctx, "RL: Status", slog.Int("status", s))
+	logger.ExtremeContext(ctx, "RL: Status", slog.Int("status", s))
 }

--- a/internal/hammer/loadtest/workers.go
+++ b/internal/hammer/loadtest/workers.go
@@ -30,7 +30,9 @@ import (
 	hasher "github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera/api/layout"
 	"github.com/transparency-dev/tesseract/internal/client"
+	"github.com/transparency-dev/tesseract/internal/logger"
 	"github.com/transparency-dev/tesseract/internal/types/rfc6962"
+
 	"github.com/transparency-dev/tesseract/internal/x509util"
 )
 
@@ -93,7 +95,7 @@ func (r *LeafReader) Run(ctx context.Context) {
 		if i >= size {
 			continue
 		}
-		slog.DebugContext(ctx, "LeafReader getting", slog.Uint64("index", i))
+		logger.DebugExtraContext(ctx, "LeafReader getting", slog.Uint64("index", i))
 		_, err := r.getLeaf(ctx, i, size)
 		if err != nil {
 			r.errChan <- fmt.Errorf("failed to get leaf %d: %v", i, err)
@@ -107,7 +109,7 @@ func (r *LeafReader) getLeaf(ctx context.Context, i uint64, logSize uint64) ([]b
 		return nil, fmt.Errorf("requested leaf %d >= log size %d", i, logSize)
 	}
 	if cached, _ := r.c.get(i); cached != nil {
-		slog.DebugContext(ctx, "Using cached result", slog.Uint64("index", i))
+		logger.DebugExtraContext(ctx, "Using cached result", slog.Uint64("index", i))
 		return cached, nil
 	}
 
@@ -260,11 +262,11 @@ func (w *LogWriter) Run(ctx context.Context) {
 			case w.leafMMDChan <- LeafMMD{chain, index, timestamp}:
 			default:
 				// Drop if leafMMDChan is full. This could happen if the MMD verifiers are falling behind.
-				slog.DebugContext(ctx, "leafMMDChan is full: dropping leaf", slog.Uint64("index", index))
+				logger.DebugExtraContext(ctx, "leafMMDChan is full: dropping leaf", slog.Uint64("index", index))
 			}
 		}
 
-		slog.DebugContext(ctx, "Wrote leaf", slog.Uint64("index", index))
+		logger.DebugExtraContext(ctx, "Wrote leaf", slog.Uint64("index", index))
 		newLeaf = w.gen()
 	}
 }

--- a/internal/logger/gcp.go
+++ b/internal/logger/gcp.go
@@ -231,7 +231,7 @@ func mapSeverity(l slog.Level) logging.Severity {
 		return logging.Warning
 	case l >= slog.LevelInfo:
 		return logging.Info
-	case l >= slog.LevelDebug:
+	case l >= LevelExtreme:
 		return logging.Debug
 	default:
 		return logging.Default
@@ -257,7 +257,7 @@ func GCPReplaceAttr(groups []string, a slog.Attr) slog.Attr {
 			a.Value = slog.StringValue("WARNING")
 		case level >= slog.LevelInfo:
 			a.Value = slog.StringValue("INFO")
-		case level >= slog.LevelDebug:
+		case level >= LevelExtreme:
 			a.Value = slog.StringValue("DEBUG")
 		default:
 			a.Value = slog.StringValue("DEFAULT")
@@ -265,3 +265,4 @@ func GCPReplaceAttr(groups []string, a slog.Attr) slog.Attr {
 	}
 	return a
 }
+

--- a/internal/logger/levels.go
+++ b/internal/logger/levels.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"context"
+	"log/slog"
+)
+
+const (
+	LevelDebugExtra = slog.Level(-8)
+	LevelExtreme    = slog.Level(-12)
+)
+
+func DebugExtraContext(ctx context.Context, msg string, args ...any) {
+	slog.Default().Log(ctx, LevelDebugExtra, msg, args...)
+}
+
+func ExtremeContext(ctx context.Context, msg string, args ...any) {
+	slog.Default().Log(ctx, LevelExtreme, msg, args...)
+}

--- a/storage/gcp/issuers.go
+++ b/storage/gcp/issuers.go
@@ -27,7 +27,9 @@ import (
 
 	gcs "cloud.google.com/go/storage"
 	"github.com/google/go-cmp/cmp"
+	"github.com/transparency-dev/tesseract/internal/logger"
 	"github.com/transparency-dev/tesseract/internal/types/staticct"
+
 	"github.com/transparency-dev/tesseract/storage"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/googleapi"
@@ -164,7 +166,7 @@ func (s *IssuersStorage) AddIfNotExist(ctx context.Context, kv []storage.KV) err
 						slog.ErrorContext(ctx, "Resource non-idempotent write", slog.String("name", objName), slog.String("diff", cmp.Diff(existing, kv.V)))
 						return fmt.Errorf("precondition failed: resource content for %q differs from data to-be-written", objName)
 					}
-					slog.DebugContext(ctx, "AddIssuersIfNotExist: object with same data already exists, continuing", slog.String("name", objName), slog.String("bucket", s.bucket.BucketName()))
+					logger.DebugExtraContext(ctx, "AddIssuersIfNotExist: object with same data already exists, continuing", slog.String("name", objName), slog.String("bucket", s.bucket.BucketName()))
 					return nil
 				}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -31,7 +31,9 @@ import (
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api/layout"
 	"github.com/transparency-dev/tessera/ctonly"
+	"github.com/transparency-dev/tesseract/internal/logger"
 	"github.com/transparency-dev/tesseract/internal/types/staticct"
+
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -181,7 +183,7 @@ func cachedStoreIssuers(s IssuerStorage) func(context.Context, []KV) error {
 			_, ok := m[string(kv.K)]
 			mu.RUnlock()
 			if ok {
-				slog.DebugContext(ctx, "cachedStoreIssuers wrapper: found in local key cache", slog.String("key", string(kv.K)))
+				logger.DebugExtraContext(ctx, "cachedStoreIssuers wrapper: found in local key cache", slog.String("key", string(kv.K)))
 				continue
 			}
 			req = append(req, kv)
@@ -191,7 +193,7 @@ func cachedStoreIssuers(s IssuerStorage) func(context.Context, []KV) error {
 		}
 		for _, kv := range req {
 			if len(m) >= maxCachedIssuerKeys {
-				slog.DebugContext(ctx, "cachedStoreIssuers wrapper: local issuer cache full, will stop caching issuers.")
+				logger.DebugExtraContext(ctx, "cachedStoreIssuers wrapper: local issuer cache full, will stop caching issuers.")
 				return nil
 			}
 			mu.Lock()


### PR DESCRIPTION
This PR implements two new structured logging levels:
 - LevelDebugExtra (-8)
 - LevelExtreme (-12)

It adds contextual convenience wrappers in the logger package. The new custom levels are filtered client-side to restrict ingestion volumes and automatically normalize down to standard DEBUG severities when exported to Google Cloud Logging. This should allow very similar filtering as we had before #841.
