### PR TITLE
Include errors in logging

### DIFF
--- a/internal/logger/gcp.go
+++ b/internal/logger/gcp.go
@@ -184,7 +184,13 @@ func (h *Exporter) Handle(ctx context.Context, r slog.Record) error {
 		// in the entry.
 		case slog.LevelKey, slog.TimeKey:
 		default:
-			target[a.Key] = a.Value.Any()
+			v := a.Value.Any()
+			// Map types to something JSON serialisable.
+			if err, ok := v.(error); ok {
+				target[a.Key] = err.Error()
+			} else {
+				target[a.Key] = v
+			}
 		}
 		return true
 	})


### PR DESCRIPTION
This fixes https://github.com/transparency-dev/tesseract/issues/850 by ensuring that error types are converted into JSON-serializable strings. I can't think of other types than error where we'd log something that isn't a string/int primitive, but if needed, more can be added here.