### PR TITLE
Sanitise HTTP body closing

### DIFF
--- a/internal/client/fetcher.go
+++ b/internal/client/fetcher.go
@@ -99,6 +99,8 @@ func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 			return nil, fmt.Errorf("get(%q): %v", u.String(), err)
 		}
 		defer func() {
+			// Drain all bytes left in the body and close it to allow socket reuse
+			_, _ = io.Copy(io.Discard, r.Body)
 			if err := r.Body.Close(); err != nil {
 				slog.ErrorContext(ctx, "resp.Body.Close()", slog.Any("error", err))
 			}

--- a/internal/client/fetcher.go
+++ b/internal/client/fetcher.go
@@ -98,6 +98,11 @@ func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("get(%q): %v", u.String(), err)
 		}
+		defer func() {
+			if err := r.Body.Close(); err != nil {
+				slog.ErrorContext(ctx, "resp.Body.Close()", slog.Any("error", err))
+			}
+		}()
 		switch r.StatusCode {
 		case http.StatusOK:
 			// All good, continue below
@@ -120,11 +125,6 @@ func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 			return nil, fmt.Errorf("get(%q): %v", u.String(), r.StatusCode)
 		}
 
-		defer func() {
-			if err := r.Body.Close(); err != nil {
-				slog.ErrorContext(ctx, "resp.Body.Close()", slog.Any("error", err))
-			}
-		}()
 		return io.ReadAll(r.Body)
 	}, h.backOff...)
 }

--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -498,8 +498,10 @@ func httpWriter(u *url.URL, hc *http.Client, bearerToken string) loadtest.LeafWr
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to write leaf: %v", err)
 		}
+		defer func() {
+			_ = resp.Body.Close()
+		}()
 		body, err := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to read body: %v", err)
 		}

--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -499,6 +499,8 @@ func httpWriter(u *url.URL, hc *http.Client, bearerToken string) loadtest.LeafWr
 			return 0, 0, fmt.Errorf("failed to write leaf: %v", err)
 		}
 		defer func() {
+			// Drain all bytes left in the body and close it to allow socket reuse
+			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 		}()
 		body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
A HTTP request body MUST be closed before returning. Failure to do so can lead to memory and socket leaks. This change moves the deferred close immediately after the HTTP request is confirmed to have returned a response.
