### PR TITLE
[Docs] Add GOMEMLIMIT configuration guidance

### DIFF
--- a/cmd/tesseract/README.md
+++ b/cmd/tesseract/README.md
@@ -276,7 +276,11 @@ are kept in memory
 sequenced in a batch
 - [The number of cached issuers keys](https://github.com/transparency-dev/tesseract/blob/main/storage/storage.go)
 - `enable_publication_awaiter` and `http_deadline`: they impact the number of
-concurrent requests, hence the amount of RAM being used
+  concurrent requests, hence the amount of RAM being used
+
+> [!IMPORTANT]
+> **GOMEMLIMIT Configuration Notice**
+> Setting GOMEMLIMIT can greatly improve the stability of at least the POSIX implementation when using BadgerDB. See the [POSIX docmentation](./posix/README.md) for more details.
 
 #### Frontend redundancy
 

--- a/cmd/tesseract/posix/README.md
+++ b/cmd/tesseract/posix/README.md
@@ -35,6 +35,19 @@ work too, `CephFS` may work, but `NFS` will almost certainly not.
 > semantics is overwhelmingly likely to result in a broken log!
 
 
+## Memory Considerations & GOMEMLIMIT
+
+Since the POSIX storage implementation utilizes BadgerDB, it is susceptible to memory spikes during LSM tree compaction. Under standard Go GC rules, these spikes can reach up to 10GB, leading to container OOM (Out Of Memory) crashes.
+
+To ensure service stability, we strongly recommend setting the `GOMEMLIMIT` environment variable.
+
+> [!IMPORTANT]
+> **GOMEMLIMIT Recommendation**
+> - **Why it is needed**: BadgerDB compaction spikes Go heap allocations, causing container OOMs due to standard Go GC lag.
+> - **How it helps**: It forces the Go runtime to trigger GC aggressively when approaching the limit, preventing OOMs.
+> - **Recommended setting**: 80-90% of the container's total memory limit (e.g., `GOMEMLIMIT=1.8GiB` for a 2GiB container).
+
+
 ## Witnessing
 
 > [!WARNING]


### PR DESCRIPTION
Explain why GOMEMLIMIT is needed for BadgerDB and recommend settings.
This makes the docs from
https://github.com/transparency-dev/tessera/pull/976 more discoverable
to users of TesseraCT.
