### PR TITLE
Log error at error level for 500 errors

### DIFF
--- a/internal/ct/handlers.go
+++ b/internal/ct/handlers.go
@@ -246,7 +246,11 @@ func (a appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			statusCode = ClientClosedRequestStatus
 			err = fmt.Errorf("client closed the connection: %v", err)
 		}
-		slog.WarnContext(ctx, "handler error", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.Any("error", err))
+		if statusCode == http.StatusInternalServerError {
+			slog.ErrorContext(ctx, "handler error", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.Any("error", err))
+		} else {
+			slog.WarnContext(ctx, "handler error", slog.String("origin", a.log.origin), slog.String("name", a.name), slog.Any("error", err))
+		}
 		a.opts.sendHTTPError(w, statusCode, err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())


### PR DESCRIPTION
An HTTP 500 should be logged as an error since an operator likely needs
to take action to fix the problem.