### PR TITLE
Ignore Tessera updates <= 1.0.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
   # CompactionInterval/BadgerOptions).
   ignore:
     - dependency-name: "github.com/transparency-dev/tessera"
-      versions: ["1.0.4"]
+      versions: ["<= 1.0.4"]
 
 - package-ecosystem: github-actions
   directory: /


### PR DESCRIPTION
This should prevent dependabot PRs rolling back the tessera dep like https://github.com/transparency-dev/tesseract/pull/920.